### PR TITLE
Fixes idxbroker/wordpress-plugin#65

### DIFF
--- a/idx/initiate-plugin.php
+++ b/idx/initiate-plugin.php
@@ -142,8 +142,9 @@ class Initiate_Plugin
         global $post;
         //If wrapper, add noindex tag which is stripped out by our system
         if ($post && $post->post_type === 'idx-wrapper') {
-            echo "<meta name='idx-robot'>\n";
-            echo "<meta name='robots' content='noindex,nofollow'>\n";
+            
+            // If html is being modified we offer filters for developers to modify this tag as needed.
+            echo apply_filters( 'idx_activation_meta_tags', "<meta name='idx-robot'>\n<meta name='robots' content='noindex,nofollow'>\n");
         }
     }
 


### PR DESCRIPTION
This pull request proposes a fix for issue #65 where IDX Broker wrapper pages were not being index by the search engines when html is minified. This fix allows developers to modify these tags if needed by passing them through an appy_filters function