### PR TITLE
Fixes PHP notice when using Advanced Custom Fields Pro.

### DIFF
--- a/idx/views/lead-management.php
+++ b/idx/views/lead-management.php
@@ -610,7 +610,7 @@ class Lead_Management {
 
 		/* Create an empty post object for dumb plugins like soliloquy */
 		global $post;
-		$post = (object) array('post_type' => null);
+		$post = (object) array('post_type' => null, 'ID' => null);
 
 	}
 


### PR DESCRIPTION
When ACF Pro is active, the IDX Broker Leads management page in WP admin displays the following PHP notice with WP_DEBUG on:

"Notice: Undefined property: stdClass::$ID in /wp-content/plugins/advanced-custom-fields-pro/includes/forms/form-post.php on line 86"