### PR TITLE
removed wpreadme2md as it's no longer used.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "psr-4": {"IDX\\": "idx/"}
     },
     "require-dev": {
-        "wpreadme2markdown/wpreadme2markdown": "*",
         "stevegrunwell/wp-enforcer": "^0.5.0"
     }
 }


### PR DESCRIPTION
* #79 Removed wpreadme2md from composer.json as it's no longer used.