### PR TITLE
Fix duplicate entries in IMPress Property Carousel widgets

### DIFF
--- a/idx/widgets/impress-carousel-widget.php
+++ b/idx/widgets/impress-carousel-widget.php
@@ -95,10 +95,12 @@ class Impress_Carousel_Widget extends \WP_Widget
 
         $target = $this->target($instance['new_window']);
 
+        $widgetUUID = uniqid();
+
         $output .= '
         <script>
         jQuery(document).ready(function( $ ){
-            $(".impress-listing-carousel-' . $display . '").owlCarousel({
+            $(".impress-listing-carousel-' . $widgetUUID . '").owlCarousel({
                 items: ' . $display . ',
                 ' . $autoplay . '
                 nav: true,
@@ -118,10 +120,12 @@ class Impress_Carousel_Widget extends \WP_Widget
                         margin: 0 
                     },
                     450:{
-                        items: ' . round( $display / 2 ) . '
+                      items: '. (round( $display / 2 ) > count($properties) ? count($properties) : round( $display / 2 )) .',
+                      loop: '. (round( $display / 2 ) < count($properties) ? 'true' : 'false') .'
                     },
                     800:{
-                        items: ' . $display . '
+                      items: '. ($display > count($properties) ? count($properties) : $display) .',
+                      loop: '. ($display < count($properties) ? 'true' : 'false') .'
                     }
                 }
             });


### PR DESCRIPTION
Resolves issue with carousel widgets showing duplicate listings when there are fewer listings than display items set. Display items are now responsive so if the widget is set to show 3 items but only 2 listings are returned the display items will expand to fill in the blank spot. 