### PR TITLE
Fix for duplicate entries in IMPress Property Carousel widgets

### DIFF
--- a/idx/shortcodes/register-impress-shortcodes.php
+++ b/idx/shortcodes/register-impress-shortcodes.php
@@ -579,11 +579,13 @@ class Register_Impress_Shortcodes {
                             margin: 0
                         },
                         450:{
-                            items: ' . round( $display / 2 ) . '
-                        },
-                        800:{
-                            items: ' . $display . '
-                        }
+							items: ' . ( round( $display / 2 ) > count( $properties ) ? count( $properties ) : round( $display / 2 ) ) . ',
+							  loop: ' . ( round( $display / 2 ) < count( $properties ) ? 'true' : 'false' ) . '
+						},
+						800:{
+							items: ' . ( $display > count( $properties ) ? count( $properties ) : $display ) . ',
+							  loop: ' . ( $display < count( $properties ) ? 'true' : 'false' ) . '
+						}
                     }
                 });
             });

--- a/idx/widgets/impress-carousel-widget.php
+++ b/idx/widgets/impress-carousel-widget.php
@@ -132,10 +132,12 @@ class Impress_Carousel_Widget extends \WP_Widget {
                         margin: 0
                     },
                     450:{
-                        items: ' . round( $display / 2 ) . '
+                        items: ' . ( round( $display / 2 ) > count( $properties ) ? count( $properties ) : round( $display / 2 ) ) . ',
+                      	loop: ' . ( round( $display / 2 ) < count( $properties ) ? 'true' : 'false' ) . '
                     },
                     800:{
-                        items: ' . $display . '
+                        items: ' . ( $display > count( $properties ) ? count( $properties ) : $display ) . ',
+                      	loop: ' . ( $display < count( $properties ) ? 'true' : 'false' ) . '
                     }
                 }
             });


### PR DESCRIPTION
Prevents duplicate listings from appearing in carousel widget when number of listings is less than the number of display slots. 