### PR TITLE
Prevent IMPress Carousel widget from loading before jQuery

### DIFF
--- a/idx/shortcodes/register-impress-shortcodes.php
+++ b/idx/shortcodes/register-impress-shortcodes.php
@@ -558,7 +558,7 @@ class Register_Impress_Shortcodes {
 		// All Instance Values are strings for shortcodes but not widgets.
 		$output .= '
             <script>
-              window.onload = function(){
+              window.addEventListener("DOMContentLoaded", (event) => {
                 jQuery(".impress-listing-carousel-' . $display . '").owlCarousel({
                     items: ' . $display . ',
                     ' . $autoplay_param . '
@@ -586,7 +586,7 @@ class Register_Impress_Shortcodes {
                         }
                     }
                 });
-              }
+              });
             </script>
             ';
 

--- a/idx/shortcodes/register-impress-shortcodes.php
+++ b/idx/shortcodes/register-impress-shortcodes.php
@@ -502,7 +502,7 @@ class Register_Impress_Shortcodes {
 		);
 
 		wp_enqueue_style( 'owl2-css', plugins_url( '../assets/css/widgets/owl2.carousel.css', dirname( __FILE__ ) ) );
-		wp_enqueue_script( 'owl2', plugins_url( '../assets/js/owl2.carousel.min.js', dirname( __FILE__ ) ) );
+		wp_enqueue_script('owl2', plugins_url('../assets/js/owl2.carousel.min.js', dirname(__FILE__)), array('jquery'), NULL, false);
 
 		if ( $styles ) {
 			wp_enqueue_style( 'impress-carousel', plugins_url( '../assets/css/widgets/impress-carousel.css', dirname( __FILE__ ) ) );
@@ -558,8 +558,8 @@ class Register_Impress_Shortcodes {
 		// All Instance Values are strings for shortcodes but not widgets.
 		$output .= '
             <script>
-            jQuery(document).ready(function( $ ){
-                $(".impress-listing-carousel-' . $display . '").owlCarousel({
+              window.onload = function(){
+                jQuery(".impress-listing-carousel-' . $display . '").owlCarousel({
                     items: ' . $display . ',
                     ' . $autoplay_param . '
                     nav: true,
@@ -586,7 +586,7 @@ class Register_Impress_Shortcodes {
                         }
                     }
                 });
-            });
+              }
             </script>
             ';
 

--- a/idx/widgets/impress-carousel-widget.php
+++ b/idx/widgets/impress-carousel-widget.php
@@ -59,7 +59,7 @@ class Impress_Carousel_Widget extends \WP_Widget {
 	 */
 	public function body( $instance ) {
 		wp_enqueue_style( 'owl2-css', plugins_url( '../assets/css/widgets/owl2.carousel.css', dirname( __FILE__ ) ) );
-		wp_enqueue_script( 'owl2', plugins_url( '../assets/js/owl2.carousel.min.js', dirname( __FILE__ ) ) );
+		wp_enqueue_script('owl2', plugins_url('../assets/js/owl2.carousel.min.js', dirname(__FILE__)), array('jquery'), NULL, false);
 
 		if ( empty( $instance ) ) {
 			$instance = $this->defaults;
@@ -111,8 +111,8 @@ class Impress_Carousel_Widget extends \WP_Widget {
 
 		$output .= '
         <script>
-        jQuery(document).ready(function( $ ){
-            $(".impress-listing-carousel-' . $display . '").owlCarousel({
+          window.onload = function(){
+            jQuery(".impress-listing-carousel-' . $display . '").owlCarousel({
                 items: ' . $display . ',
                 ' . $autoplay . '
                 nav: true,
@@ -139,7 +139,7 @@ class Impress_Carousel_Widget extends \WP_Widget {
                     }
                 }
             });
-        });
+          }
         </script>
         ';
 

--- a/idx/widgets/impress-carousel-widget.php
+++ b/idx/widgets/impress-carousel-widget.php
@@ -111,7 +111,7 @@ class Impress_Carousel_Widget extends \WP_Widget {
 
 		$output .= '
         <script>
-          window.onload = function(){
+          window.addEventListener("DOMContentLoaded", (event) => {
             jQuery(".impress-listing-carousel-' . $display . '").owlCarousel({
                 items: ' . $display . ',
                 ' . $autoplay . '
@@ -139,7 +139,7 @@ class Impress_Carousel_Widget extends \WP_Widget {
                     }
                 }
             });
-          }
+          });
         </script>
         ';
 


### PR DESCRIPTION
Fix to prevent IMPress Carousel widget from loading before jQuery on themes where it is placed in wp_footer (e.g. the "Twenty Nineteen" theme).