### PR TITLE
Added handling for missing $instance

### DIFF
--- a/idx/shortcodes/register-impress-shortcodes.php
+++ b/idx/shortcodes/register-impress-shortcodes.php
@@ -292,7 +292,7 @@ class Register_Impress_Shortcodes {
 						$target
 					),
 					$prop,
-					$instance,
+					( isset( $instance ) ? $instance : [] ),
 					$url,
 					$prop_image_url,
 					$this->maybe_add_disclaimer_and_courtesy( $prop ),
@@ -337,7 +337,7 @@ class Register_Impress_Shortcodes {
 						$target
 					),
 					$prop,
-					$instance,
+					( isset( $instance ) ? $instance : [] ),
 					$url,
 					$column_class,
 					$target


### PR DESCRIPTION
This is to avoid error log entries when placing a widget using the Gutenberg editor. 