### PR TITLE
WP-1046: CSS Change to Prevent Shortcode Button from Changing Dimensions

### DIFF
--- a/assets/css/idx-shortcode.css
+++ b/assets/css/idx-shortcode.css
@@ -1,8 +1,11 @@
+#idx-shortcode {
+    height: 30px;
+}
 #idx-shortcode:before {
     content: '\e021';
     font-family: 'properticons';
     margin-right: 0.3rem;
-    margin-top: -2px;
+    margin-top: -39px;
     font-size: 3rem;
     color: #82878c;
     float: left;


### PR DESCRIPTION
Minor CSS tweak to prevent the IDXB shortcode button from expanding past its bounds when using the classic editor. 