### PR TITLE
Changes to how 'Add_Uid_To_Idx_Pages' is returned when the 'idx_added_uid_to_idx_pages' option is empty

### DIFF
--- a/idx/idx-pages.php
+++ b/idx/idx-pages.php
@@ -330,10 +330,10 @@ class Idx_Pages {
 	 * Deletes IDX pages that dont have a url or title matching a systemlink url or title
 	 */
 	public function delete_idx_pages() {
-		// Only schedule update once IDX pages have UID
+		// Only schedule update once IDX pages have UID.
 		$uid_added = get_option( 'idx_added_uid_to_idx_pages' );
 		if ( empty( $uid_added ) ) {
-			return $this->app->make( '\IDX\Backward_Compatibility\Add_Uid_To_Idx_Pages' );
+			return new Backward_Compatibility\Add_Uid_To_Idx_Pages();
 		}
 
 		$posts = get_posts(


### PR DESCRIPTION
'$this->app->make()' does not work as '$this' does not have a property called 'app' when 'make()' is called. Changed the line to simply return a new instance of the 'Add_Uid_To_Idx_Pages' as that appears to be the end-goal here.