### PR TITLE
Simplified Pt-level account check

### DIFF
--- a/idx/idx-api.php
+++ b/idx/idx-api.php
@@ -787,7 +787,7 @@ class Idx_Api {
 	 */
 	public function platinum_account_type() {
 		$account_type = $this->idx_api( 'accounttype', Initiate_Plugin::IDX_API_DEFAULT_VERSION, 'clients', array(), 60 * 60 * 24 );
-		if ( 'object' !== gettype( $account_type ) && ( 'IDX Broker Platinum' === $account_type[0] || 'IDX Broker Platinum Legacy' === $account_type[0] || 'IDX Broker HOME' === $account_type[0] || 'IDX Broker HOME Legacy' === $account_type[0] ) ) {
+		if ( 'object' !== gettype( $account_type ) && ( stripos( $account_type[0], 'plat' ) || stripos( $account_type[0], 'home' ) ) ) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Changed from exact string matching to case-insensitive sub-string matching to determine Pt/Home account levels.