### PR TITLE
Updated default omnibar prop type to match UI

### DIFF
--- a/idx/widgets/omnibar/create-omnibar.php
+++ b/idx/widgets/omnibar/create-omnibar.php
@@ -166,7 +166,7 @@ EOD;
 			$mlsPtIDs = array(
 				array(
 					'idxID'   => '',
-					'mlsPtID' => 1,
+					'mlsPtID' => 'all',
 				),
 			);
 		}


### PR DESCRIPTION
* Updated default property type value to 'all' so it matches the default value shown in the omnibar settings UI, 'All Property Types'