### PR TITLE
Removed duplicate OwlCarousel options

### DIFF
--- a/idx/shortcodes/register-impress-shortcodes.php
+++ b/idx/shortcodes/register-impress-shortcodes.php
@@ -568,8 +568,6 @@ class Register_Impress_Shortcodes {
 			    lazyLoad: true,
 			    addClassActive: true,
 			    itemsScaleUp: true,
-			    addClassActive: true,
-			    itemsScaleUp: true,
 			    navContainerClass: "owl-controls owl-nav",
 			    responsiveClass:true,
 			    responsive:{

--- a/idx/widgets/impress-carousel-widget.php
+++ b/idx/widgets/impress-carousel-widget.php
@@ -121,8 +121,6 @@ class Impress_Carousel_Widget extends \WP_Widget {
 						lazyLoad: true,
 						addClassActive: true,
 						itemsScaleUp: true,
-						addClassActive: true,
-						itemsScaleUp: true,
 						navContainerClass: "owl-controls owl-nav",
 						responsiveClass:true,
 						responsive:{


### PR DESCRIPTION
Removed duplicate settings options in the OwlCarousel instance used to power the IMPress Carousel widget