### PR TITLE
Fix for agent matching issue

### DIFF
--- a/idx/shortcodes/register-impress-shortcodes.php
+++ b/idx/shortcodes/register-impress-shortcodes.php
@@ -196,8 +196,8 @@ class Register_Impress_Shortcodes {
 
 		foreach ( $properties as $prop ) {
 
-			if ( isset( $agent_id, $prop['userAgentID'] ) && ! empty( $agent_id ) ) {
-				if ( (int) $agent_id !== (int) $prop['userAgentID'] ) {
+			if ( ! empty( $agent_id ) ) {
+				if ( empty( $prop['userAgentID'] ) || (int) $agent_id !== (int) $prop['userAgentID'] ) {
 					continue;
 				}
 			}

--- a/idx/widgets/impress-showcase-widget.php
+++ b/idx/widgets/impress-showcase-widget.php
@@ -140,8 +140,8 @@ class Impress_Showcase_Widget extends \WP_Widget {
 
 		foreach ( $properties as $prop ) {
 
-			if ( isset( $instance['agentID'], $prop['userAgentID'] ) && ! empty( $instance['agentID'] ) ) {
-				if ( $instance['agentID'] !== (int) $prop['userAgentID'] ) {
+			if ( ! empty( $instance['agentID'] ) ) {
+				if ( empty( $prop['userAgentID'] ) || (int) $instance['agentID'] !== (int) $prop['userAgentID'] ) {
 					continue;
 				}
 			}


### PR DESCRIPTION
Updated agent ID check for showcase widgets as a missing/empty userAgentID on a property could cause a false match.