### PR TITLE
UXG-1298: Added nested router views and layout scaffolding.

### DIFF
--- a/assets/css/idx-broker.css
+++ b/assets/css/idx-broker.css
@@ -1,3 +1,6 @@
+#wpcontent {
+    padding: 0;
+}
 #logo {
     background-image: url(../images/logo-wp.png);
     background-repeat: no-repeat;

--- a/src/vue/backend/src/App.vue
+++ b/src/vue/backend/src/App.vue
@@ -1,24 +1,18 @@
 <template>
-  <idx-block className="app">
-    <Navbar></Navbar>
-    <page>
-        <transition name="router" mode="out-in">
-            <router-view></router-view>
-        </transition>
-    </page>
-  </idx-block>
+    <idx-block className="app">
+        <router-view></router-view>
+    </idx-block>
 </template>
 <script>
-import Navbar from './templates/navbar'
-import Page from './templates/page'
 export default {
-    name: 'app',
-    components: {
-        Navbar,
-        Page
-    }
+    name: 'app'
 }
 </script>
 <style lang="scss">
-@import '~@idxbrokerllc/idxstrap/dist/styles/components/vNav';
+.app {
+    h2 {
+        display: block;
+        float: unset;
+    }
+}
 </style>

--- a/src/vue/backend/src/components/BulkAction.vue
+++ b/src/vue/backend/src/components/BulkAction.vue
@@ -1,0 +1,28 @@
+<template>
+    <div>
+        <idx-block className="import-header__description">{{ description }}</idx-block>
+        <idx-block className="import-header__actions-bar">
+            <idx-block className="import-header__select-all" @click="$emit('select-all', selected)">{{ selected ? 'Select All' : 'Deselect All' }}</idx-block>
+            <idx-button customClass="import-header__action" @click="$emit('bulk-action', action)">{{ action }} Selected</idx-button>
+        </idx-block>
+    </div>
+</template>
+<script>
+export default {
+    name: 'bulk-action',
+    props: {
+        selected: {
+            type: Boolean,
+            default: false
+        },
+        action: {
+            type: String,
+            default: 'Import'
+        },
+        description: {
+            type: String,
+            default: ''
+        }
+    }
+}
+</script>

--- a/src/vue/backend/src/data/navlinks.js
+++ b/src/vue/backend/src/data/navlinks.js
@@ -14,7 +14,7 @@ const _navLinks = [
         collapsed: true,
         routes: [
             { label: 'Agents', link: '/import/agents/' },
-            { label: 'Listings', link: '/import/listings' }
+            { label: 'Listings', link: '/import/listings/' }
         ]
     },
     {

--- a/src/vue/backend/src/mixins/Tabbed.js
+++ b/src/vue/backend/src/mixins/Tabbed.js
@@ -1,0 +1,36 @@
+export default {
+    props: {
+        parentRoute: {
+            type: String,
+            required: true
+        },
+        tabbedRoutes: {
+            type: Array,
+            default: () => []
+        }
+    },
+    computed: {
+        tabs () {
+            return this.tabbedRoutes.map(route => route.label)
+        },
+        activeTab () {
+            const { fullPath } = this.$route
+            let index = 0
+            this.tabbedRoutes.forEach((route, i) => {
+                if (`${this.parentRoute}/${route.path}` === fullPath) {
+                    index = i
+                }
+            })
+            return index
+        }
+    },
+    methods: {
+        switchTab (index) {
+            /* Prevent redundant navigation error */
+            if (index !== this.activeTab) {
+                const route = this.tabbedRoutes[index].path
+                this.$router.push(`${this.parentRoute}/${route}`)
+            }
+        }
+    }
+}

--- a/src/vue/backend/src/router/index.js
+++ b/src/vue/backend/src/router/index.js
@@ -1,163 +1,163 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 import GuidedSetup from '@/views/GuidedSetup.vue'
-
+import Generic from '@/templates/layout/Generic'
+import Layout from '@/templates/layout/Layout'
+import routeMeta from './routeMeta'
 Vue.use(VueRouter)
 
 const routes = [
     {
-        path: '/import',
-        name: 'Import',
+        path: '',
+        component: Layout,
         children: [
             {
-                path: 'listings',
-                name: 'Unimported IDX Listings'
-                // component
-            },
-            {
-                path: 'listings/imported',
-                name: 'Imported IDX Listings'
-                // component
-            },
-            {
-                path: 'agents',
-                name: 'Unimported Agents'
-                // component
-            },
-            {
-                path: 'agents/imported',
-                name: 'Imported Agents'
-                // component
-            }
-        ]
-    },
-    {
-        path: '/settings',
-        name: 'Settings',
-        children: [
-            {
-                path: 'general',
-                name: 'IMPress General Settings'
-                // component
-            },
-            {
-                path: 'omnibar',
-                name: 'IMPress Omnibar Settings'
-                // component
-            },
-            {
-                path: 'listings',
+                path: '/import',
+                name: 'Import',
+                component: Generic,
                 children: [
                     {
-                        path: '',
-                        name: 'IMPress Listings General Settings'
-                        // component
+                        path: 'listings',
+                        name: 'IDX Listings',
+                        component: () => import('@/views/import/Listings'),
+                        children: routeMeta.imports.listings,
+                        props: {
+                            parentRoute: '/import/listings',
+                            tabbedRoutes: routeMeta.imports.listings
+                        }
                     },
                     {
-                        path: 'idx',
-                        name: 'IMPress Listings IDX Settings'
-                        // component
-                    },
-                    {
-                        path: 'advanced',
-                        name: 'IMPress Listings Advanced Settings'
-                        // component
+                        path: 'agents',
+                        name: 'IDX Agents',
+                        component: () => import('@/views/import/Agents'),
+                        children: routeMeta.imports.agents,
+                        props: {
+                            parentRoute: '/import/agents',
+                            tabbedRoutes: routeMeta.imports.agents
+                        }
                     }
                 ]
             },
             {
-                path: 'agents',
-                name: 'IMPress Agents Settings'
-                // component
-            },
-            {
-                path: 'social-pro',
-                name: 'Social Pro Settings'
-                // component
-            },
-            {
-                path: 'gmb',
-                name: 'Google My Business'
-            }
-        ]
-    },
-    {
-        path: '/guided-setup',
-        name: 'Guided Setup',
-        component: GuidedSetup,
-        children: [
-            {
-                path: 'connect',
+                path: '/settings',
+                name: 'Settings',
+                component: Generic,
                 children: [
                     {
-                        path: 'api',
-                        name: 'Connect Account'
-                        // component
-                    },
-                    {
                         path: 'general',
-                        name: 'General Settings'
-                        // component
+                        name: 'IMPress General Settings',
+                        component: () => import('@/views/settings/General')
                     },
                     {
                         path: 'omnibar',
-                        name: 'Omnibar Settings'
-                        // component
+                        name: 'IMPress Omnibar Settings',
+                        component: () => import('@/views/settings/Omnibar')
+                    },
+                    {
+                        path: 'listings',
+                        component: () => import('@/views/settings/Listings'),
+                        children: routeMeta.settings.listings,
+                        props: {
+                            parentRoute: '/settings/listings',
+                            tabbedRoutes: routeMeta.settings.listings
+                        }
+                    },
+                    {
+                        path: 'agents',
+                        name: 'IMPress Agents Settings',
+                        component: () => import('@/views/settings/Agents')
+                    },
+                    {
+                        path: 'social-pro',
+                        name: 'Social Pro Settings',
+                        component: () => import('@/views/settings/SocialPro')
+                    },
+                    {
+                        path: 'gmb',
+                        name: 'Google My Business',
+                        component: () => import('@/views/settings/GMB')
                     }
                 ]
             },
             {
-                path: 'listings',
+                path: '/guided-setup',
+                name: 'Guided Setup',
+                component: GuidedSetup,
                 children: [
                     {
-                        path: 'activate',
-                        name: 'Activate IMPress Listings'
-                        // component
+                        path: 'connect',
+                        children: [
+                            {
+                                path: 'api',
+                                name: 'Connect Account'
+                                // component
+                            },
+                            {
+                                path: 'general',
+                                name: 'General Settings'
+                                // component
+                            },
+                            {
+                                path: 'omnibar',
+                                name: 'Omnibar Settings'
+                                // component
+                            }
+                        ]
                     },
                     {
-                        path: 'general',
-                        name: 'Configure General IMPress Listings'
-                        // component
+                        path: 'listings',
+                        children: [
+                            {
+                                path: 'activate',
+                                name: 'Activate IMPress Listings'
+                                // component
+                            },
+                            {
+                                path: 'general',
+                                name: 'Configure General IMPress Listings'
+                                // component
+                            },
+                            {
+                                path: 'idx',
+                                name: 'Configure IDX IMPress Listings'
+                                // component
+                            },
+                            {
+                                path: 'advanced',
+                                name: 'Configure Advanced IMPress Listings'
+                                // component
+                            }
+                        ]
                     },
                     {
-                        path: 'idx',
-                        name: 'Configure IDX IMPress Listings'
-                        // component
+                        path: 'agents',
+                        children: [
+                            {
+                                path: 'activate',
+                                name: 'Activate IMPress Agents'
+                                // component
+                            },
+                            {
+                                path: 'configure',
+                                name: 'Configure IMPress Agents'
+                                // component
+                            }
+                        ]
                     },
                     {
-                        path: 'advanced',
-                        name: 'Configure Advanced IMPress Listings'
-                        // component
-                    }
-                ]
-            },
-            {
-                path: 'agents',
-                children: [
-                    {
-                        path: 'activate',
-                        name: 'Activate IMPress Agents'
-                        // component
-                    },
-                    {
-                        path: 'configure',
-                        name: 'Configure IMPress Agents'
-                        // component
-                    }
-                ]
-            },
-            {
-                path: 'social-pro',
-                children: [
-                    {
-                        path: 'activate',
-                        name: 'Activate Social Pro'
-                        // component
-                    },
-                    {
-                        path: 'general',
-                        name: 'Configure Social Pro'
-                        // component
+                        path: 'social-pro',
+                        children: [
+                            {
+                                path: 'activate',
+                                name: 'Activate Social Pro'
+                                // component
+                            },
+                            {
+                                path: 'general',
+                                name: 'Configure Social Pro'
+                                // component
+                            }
+                        ]
                     }
                 ]
             }

--- a/src/vue/backend/src/router/routeMeta.js
+++ b/src/vue/backend/src/router/routeMeta.js
@@ -1,0 +1,40 @@
+/**
+ * Route Meta
+ * Uses:
+ * Use when passing route information as props to a route component, while simultaneously passing to route.children.
+ */
+export default {
+    settings: {
+        listings: [{
+            path: '',
+            name: 'IMPress Listings General Settings',
+            label: 'General',
+            // component
+            component: () => import('@/templates/ListingsGeneral.vue')
+        },
+        {
+            path: 'idx',
+            name: 'IMPress Listings IDX Settings',
+            label: 'IDX',
+            // component
+            component: () => import('@/templates/impressListingsIdxContent')
+        },
+        {
+            path: 'advanced',
+            name: 'IMPress Listings Advanced Settings',
+            label: 'Advanced',
+            // component
+            component: () => import('@/templates/impressListingsAdvancedContent')
+        }]
+    },
+    imports: {
+        listings: [
+            { path: '', name: 'Unimported IDX Listings', label: 'Unimported' /* Component here */ },
+            { path: 'imported', name: 'Imported IDX Listings', label: 'Imported' /* Component here */ }
+        ],
+        agents: [
+            { path: '', name: 'Unimported IDX Agents', label: 'Unimported' /* Component here */ },
+            { path: 'imported', name: 'Imported IDX Agents', label: 'Imported' /* Component here */ }
+        ]
+    }
+}

--- a/src/vue/backend/src/templates/impressListingsAdvancedContent.vue
+++ b/src/vue/backend/src/templates/impressListingsAdvancedContent.vue
@@ -1,0 +1,5 @@
+<template>
+    <section id="impress-listings-advanced">
+        Advanced content here.
+    </section>
+</template>

--- a/src/vue/backend/src/templates/layout/Generic.vue
+++ b/src/vue/backend/src/templates/layout/Generic.vue
@@ -1,0 +1,5 @@
+<template>
+    <transition name="router" mode="out-in">
+        <router-view />
+    </transition>
+</template>

--- a/src/vue/backend/src/templates/layout/Layout.vue
+++ b/src/vue/backend/src/templates/layout/Layout.vue
@@ -1,0 +1,23 @@
+<template>
+    <section id="layout">
+        <Navbar></Navbar>
+        <Page>
+            <Generic />
+        </Page>
+    </section>
+</template>
+<script>
+import Navbar from '@/templates/navbar'
+import Page from '@/templates/page'
+import Generic from '@/templates/layout/Generic'
+export default {
+    components: {
+        Generic,
+        Navbar,
+        Page
+    }
+}
+</script>
+<style lang="scss">
+@import '~@idxbrokerllc/idxstrap/dist/styles/components/vNav';
+</style>

--- a/src/vue/backend/src/templates/layout/Tabbed.vue
+++ b/src/vue/backend/src/templates/layout/Tabbed.vue
@@ -1,53 +1,28 @@
 <template>
     <idx-tab-container
         customClass="import-header"
-        @activeTab="switchTabs"
+        @activeTab="switchTab"
         :activeTab="activeTab"
-        :tabs="['Unimported', 'Imported']"
+        :tabs="tabs"
     >
-        <idx-block className="import-header__description">{{ description }}</idx-block>
-        <idx-block className="import-header__actions-bar">
-            <idx-block className="import-header__select-all" @click="$emit('select-all', selected)">{{ selected ? 'Select All' : 'Deselect All' }}</idx-block>
-            <idx-button customClass="import-header__action" @click="$emit('bulk-action', action)">{{ action }} Selected</idx-button>
-        </idx-block>
         <router-view></router-view>
     </idx-tab-container>
 </template>
 <script>
+import Tabbed from '@/mixins/Tabbed'
 export default {
-    name: 'import-header',
-    data () {
-        return {
-            activeTab: 0
-        }
-    },
-    props: {
-        selected: {
-            type: Boolean,
-            default: false
-        },
-        action: {
-            type: String,
-            default: 'Import'
-        },
-        description: {
-            type: String,
-            default: ''
-        }
-    },
-    methods: {
-        switchTabs (e) {
-            this.activeTab = e
-            /* Router change here, once we have router set up we can switch it. For now emitting and event */
-            this.$emit('switch-tabs', this.activeTab)
-        }
-    }
+    name: 'tabbed',
+    mixins: [Tabbed]
 }
 </script>
 <style lang="scss">
 @import '~@idxbrokerllc/idxstrap/dist/styles/components/buttons';
 @import '~@idxbrokerllc/idxstrap/dist/styles/components/tabContainer';
+.import-header.tab-container {
+    padding: 0;
+}
 .import-header {
+    padding: 0;
     background-color: $white;
     font-size: 1rem;
     &__description {
@@ -75,6 +50,7 @@ export default {
             justify-content: end;
             border-bottom: 1px solid $gray-150;
             height: 50px;
+            gap: 1rem;
         }
         &__tab {
             width: 164px;
@@ -84,9 +60,6 @@ export default {
             letter-spacing: 1.6px;
             color: #788088;
             text-transform: uppercase;
-            &:first-child {
-                margin-right: 18px;
-            }
         }
     }
 }

--- a/src/vue/backend/src/templates/layout/TwoColumn.vue
+++ b/src/vue/backend/src/templates/layout/TwoColumn.vue
@@ -1,0 +1,43 @@
+<template>
+    <idx-block :id="id" :className="className">
+        <idx-block className="section__content">
+            <h2>{{ title }}</h2>
+            <slot />
+        </idx-block>
+        <idx-block v-if="$slots.related" className="section__content">
+            <slot name="related" />
+        </idx-block>
+    </idx-block>
+</template>
+<script>
+export default {
+    name: 'two-column',
+    props: {
+        title: {
+            type: String,
+            required: true
+        }
+    },
+    computed: {
+        id () {
+            return this.title.toLowerCase().split(' ').join('-')
+        },
+        className () {
+            return {
+                section: true,
+                'section--two-column': !!this.$slots.related
+            }
+        }
+    }
+}
+</script>
+<style lang="scss">
+.section {
+    &--two-column {
+        display: grid;
+        grid-template-columns: 1fr 300px;
+        grid-template-rows: auto;
+        grid-gap: 4rem;
+    }
+}
+</style>

--- a/src/vue/backend/src/views/import/Agents.vue
+++ b/src/vue/backend/src/views/import/Agents.vue
@@ -1,0 +1,17 @@
+<template>
+    <div>
+        <h2>Import Agents</h2>
+        <Tabbed v-bind="$props" />
+    </div>
+</template>
+<script>
+import TabbedMixin from '@/mixins/Tabbed'
+import Tabbed from '@/templates/layout/Tabbed'
+export default {
+    mixins: [TabbedMixin],
+    components: { Tabbed }
+}
+</script>
+<style lang="scss">
+@import '~@idxbrokerllc/idxstrap/dist/styles/components/tabContainer';
+</style>

--- a/src/vue/backend/src/views/import/Listings.vue
+++ b/src/vue/backend/src/views/import/Listings.vue
@@ -1,0 +1,14 @@
+<template>
+    <section>
+        <h2>Import IDX Listings</h2>
+        <Tabbed v-bind="$props" />
+    </section>
+</template>
+<script>
+import TabbedMixin from '@/mixins/Tabbed'
+import Tabbed from '@/templates/layout/Tabbed'
+export default {
+    mixins: [TabbedMixin],
+    components: { Tabbed }
+}
+</script>

--- a/src/vue/backend/src/views/settings/Agents.vue
+++ b/src/vue/backend/src/views/settings/Agents.vue
@@ -1,0 +1,18 @@
+<template>
+    <TwoColumn title="IMPress Agents Settings">
+        <AgentsSettings />
+        <template #related>
+            Related Links here
+        </template>
+    </TwoColumn>
+</template>
+<script>
+import AgentsSettings from '@/templates/AgentsSettings'
+import TwoColumn from '@/templates/layout/TwoColumn'
+export default {
+    components: {
+        AgentsSettings,
+        TwoColumn
+    }
+}
+</script>

--- a/src/vue/backend/src/views/settings/GMB.vue
+++ b/src/vue/backend/src/views/settings/GMB.vue
@@ -1,0 +1,16 @@
+<template>
+    <TwoColumn title="Google My Business Settings">
+        <div>GMB Mount Here</div>
+        <template #related>
+            Related Links here
+        </template>
+    </TwoColumn>
+</template>
+<script>
+import TwoColumn from '@/templates/layout/TwoColumn'
+export default {
+    components: {
+        TwoColumn
+    }
+}
+</script>

--- a/src/vue/backend/src/views/settings/General.vue
+++ b/src/vue/backend/src/views/settings/General.vue
@@ -1,0 +1,18 @@
+<template>
+    <TwoColumn title="General Settings">
+        <GeneralSettings />
+        <template #related>
+            Related Links here
+        </template>
+    </TwoColumn>
+</template>
+<script>
+import TwoColumn from '@/templates/layout/TwoColumn'
+import GeneralSettings from '@/templates/GeneralSettings'
+export default {
+    components: {
+        GeneralSettings,
+        TwoColumn
+    }
+}
+</script>

--- a/src/vue/backend/src/views/settings/Listings.vue
+++ b/src/vue/backend/src/views/settings/Listings.vue
@@ -1,0 +1,23 @@
+<template>
+    <TwoColumn title="IMPress Listings Settings">
+        <Tabbed v-bind="$props" />
+        <template #related>
+            Related Links here
+        </template>
+    </TwoColumn>
+</template>
+<script>
+import TwoColumn from '@/templates/layout/TwoColumn'
+import TabbedMixin from '@/mixins/Tabbed'
+import Tabbed from '@/templates/layout/Tabbed'
+export default {
+    mixins: [TabbedMixin],
+    components: {
+        Tabbed,
+        TwoColumn
+    }
+}
+</script>
+<style lang="scss">
+@import '~@idxbrokerllc/idxstrap/dist/styles/components/tabContainer';
+</style>

--- a/src/vue/backend/src/views/settings/Omnibar.vue
+++ b/src/vue/backend/src/views/settings/Omnibar.vue
@@ -1,0 +1,17 @@
+<template>
+    <TwoColumn title="Omnibar Settings">
+        <div>Omnibar Settings Here</div>
+        <template #related>
+            Related Links here
+        </template>
+    </TwoColumn>
+</template>
+<script>
+import TwoColumn from '@/templates/layout/TwoColumn'
+export default {
+    name: 'omnibar',
+    components: {
+        TwoColumn
+    }
+}
+</script>

--- a/src/vue/backend/src/views/settings/SocialPro.vue
+++ b/src/vue/backend/src/views/settings/SocialPro.vue
@@ -1,0 +1,18 @@
+<template>
+    <TwoColumn title="Social Pro Syndication Settings">
+        <SocialProForm />
+        <template #related>
+            <div>Related Links Here.</div>
+        </template>
+    </TwoColumn>
+</template>
+<script>
+import SocialProForm from '@/templates/socialProForm'
+import TwoColumn from '@/templates/layout/TwoColumn'
+export default {
+    components: {
+        SocialProForm,
+        TwoColumn
+    }
+}
+</script>


### PR DESCRIPTION
* Adds "routerMeta" export for tabbed child nav pages / passes props to parent component
* Adds various layout scaffolding templates and views
* Modified Sarah's "importHeader.vue" into "Tabbed.vue" for reusability between tabbed views.
* Removed padding from `#wpcontent` element as it throws off our page padding
* Various other tweaks.