### PR TITLE
WP-1302: Added service container for depend/inject api usage in conta…

### DIFF
--- a/src/vue/backend/package.json
+++ b/src/vue/backend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@idxbrokerllc/idxstrap": "^3.2.1",
+    "axios": "^0.21.1",
     "core-js": "^3.6.5",
     "lodash.get": "^4.4.2",
     "normalizr": "^3.6.1",

--- a/src/vue/backend/src/main.js
+++ b/src/vue/backend/src/main.js
@@ -5,6 +5,7 @@ import App from './App.vue'
 import router from './router'
 import store from './store'
 import IDXStrapClass from '@idxbrokerllc/idxstrap/dist/idxStrap.js'
+import serviceContainer from './serviceContainer'
 
 // Import VCL base and variable styles
 import '@idxbrokerllc/idxstrap/dist/styles/base.scss'
@@ -110,5 +111,6 @@ Vue.config.productionTip = false
 new Vue({
     router,
     store,
+    provide: serviceContainer,
     render: h => h(App)
 }).$mount('#app')

--- a/src/vue/backend/src/repositories/agentSettings.class.js
+++ b/src/vue/backend/src/repositories/agentSettings.class.js
@@ -1,0 +1,10 @@
+import GenericRepositoryClass from './generic.class'
+
+class AgentSettingsRepositoryClass extends GenericRepositoryClass {
+    constructor () {
+        super()
+        this.endpoint = 'settings/agents'
+    }
+}
+
+export default AgentSettingsRepositoryClass

--- a/src/vue/backend/src/repositories/general.class.js
+++ b/src/vue/backend/src/repositories/general.class.js
@@ -1,0 +1,10 @@
+import GenericRepositoryClass from './generic.class'
+
+class GeneralRepositoryClass extends GenericRepositoryClass {
+    constructor () {
+        super()
+        this.endpoint = 'settings/general'
+    }
+}
+
+export default GeneralRepositoryClass

--- a/src/vue/backend/src/repositories/generic.class.js
+++ b/src/vue/backend/src/repositories/generic.class.js
@@ -1,0 +1,18 @@
+import instance from './instance'
+
+class GenericRepositoryClass {
+    constructor (endpoint) {
+        this.endpoint = endpoint
+        this.instance = instance
+    }
+
+    get () {
+        return this.instance.get(this.endpoint)
+    }
+
+    post (payload) {
+        return this.instance.post(this.endpoint, payload)
+    }
+}
+
+export default GenericRepositoryClass

--- a/src/vue/backend/src/repositories/instance.js
+++ b/src/vue/backend/src/repositories/instance.js
@@ -1,0 +1,11 @@
+import axios from 'axios'
+const { wpApiSettings: { nonce, root } } = window
+const instance = axios.create({
+    baseURL: `${root}idxbroker/v1/admin`,
+    withCredentials: true,
+    headers: {
+        'X-WP-Nonce': nonce
+    }
+})
+
+export default instance

--- a/src/vue/backend/src/serviceContainer.js
+++ b/src/vue/backend/src/serviceContainer.js
@@ -1,0 +1,41 @@
+/**
+ * Interface to adhere to.
+ */
+const RepositoryInterface = {
+    get () {},
+    post () {}
+}
+
+/**
+ * Dynamically load a repository file and bind it to the Repository interface.
+ * Note: The file must contain .class - ex: myfile.class.js
+ *
+ * @param {*} fileName The name of the repository file.
+ */
+const loadRepo = (fileName) => {
+    /* Using template literals breaks the dynamic import. /shrug. */
+    return bind(() => import('./repositories/' + fileName + '.class'), RepositoryInterface)
+}
+
+const bind = (repositoryFactory, Interface) => {
+    return {
+        ...Object.keys(Interface).reduce((prev, method) => {
+            const resolveableMethod = async (...args) => {
+                const repository = await repositoryFactory()
+                const instance = new repository.default() // eslint-disable-line
+                return instance[method](...args)
+            }
+            return { ...prev, [method]: resolveableMethod }
+        }, {})
+    }
+}
+
+export default {
+    get generalRepository () {
+        return loadRepo('general')
+    },
+    get agentSettingsRepository () {
+        return loadRepo('agentSettings')
+    }
+    /* Add more repositories here as they become available. */
+}

--- a/src/vue/backend/src/serviceContainer.js
+++ b/src/vue/backend/src/serviceContainer.js
@@ -20,10 +20,10 @@ const loadRepo = (fileName) => {
 const bind = (repositoryFactory, Interface) => {
     return {
         ...Object.keys(Interface).reduce((prev, method) => {
-            const resolveableMethod = async (...args) => {
+            const resolveableMethod = async (args) => {
                 const repository = await repositoryFactory()
                 const instance = new repository.default() // eslint-disable-line
-                return instance[method](...args)
+                return instance[method](args)
             }
             return { ...prev, [method]: resolveableMethod }
         }, {})


### PR DESCRIPTION
Added service container for depend/inject api repository usage in container (view) components.

## Usage

```javascript
// src/main.js
import serviceContainer from './serviceContainer'
...
new Vue({
  router,
  store,
  provide: serviceContainer,
  render: h => h(App)
}).$mount('#app')
```


```javascript
// src/views/General.vue
export default {
  // Add necessary repositories defined in service container.
  inject: ['generalRepository'],
  ...
  async created () {
    const { data } = await this.generalRepository.get()
    // handle data by dispatching action to mutate state:
    Object.keys(data).forEach(key => this.generalSettingsStateChange({ key, value: data[key] })
}
```