### PR TITLE
UXG-1245: GET/POST agent settings from/to WP REST API backend.

### DIFF
--- a/src/vue/backend/src/mixins/pageGuard.js
+++ b/src/vue/backend/src/mixins/pageGuard.js
@@ -23,7 +23,7 @@ export default {
         },
         saveAction () {
             for (const key in this.formChanges) {
-                this.setItem({ key, value: this.formChanges[key] })
+                this.$store.dispatch(`${this.module}/setItem`, { key, value: this.formChanges[key] })
             }
             this.formChanges = {}
         }

--- a/src/vue/backend/src/serviceContainer.js
+++ b/src/vue/backend/src/serviceContainer.js
@@ -20,10 +20,10 @@ const loadRepo = (fileName) => {
 const bind = (repositoryFactory, Interface) => {
     return {
         ...Object.keys(Interface).reduce((prev, method) => {
-            const resolveableMethod = async (args) => {
+            const resolveableMethod = async (...args) => {
                 const repository = await repositoryFactory()
                 const instance = new repository.default() // eslint-disable-line
-                return instance[method](args)
+                return instance[method](...args)
             }
             return { ...prev, [method]: resolveableMethod }
         }, {})

--- a/src/vue/backend/src/templates/AgentsSettings.vue
+++ b/src/vue/backend/src/templates/AgentsSettings.vue
@@ -64,7 +64,7 @@ export default {
         },
         numberOfPosts: {
             type: [String, Number],
-            default: '9'
+            default: ''
         },
         directorySlug: {
             type: String,

--- a/src/vue/backend/src/views/settings/Agents.vue
+++ b/src/vue/backend/src/views/settings/Agents.vue
@@ -1,23 +1,71 @@
 <template>
     <TwoColumn title="IMPress Agents Settings">
-        <AgentsSettings />
+        <idx-block className="form-content">
+            <idx-block className="form-content__toggle">
+                Enable
+                <idx-toggle-slider
+                    uncheckedState="No"
+                    checkedState="Yes"
+                    @toggle="refreshPage"
+                    :active="agentSettings.enabled"
+                    label="Enable IMPress Listings"
+                ></idx-toggle-slider>
+            </idx-block>
+            <template v-if="agentSettings.enabled">
+                <AgentsSettings v-bind="agentSettings" @form-field-update="formUpdate" />
+                <idx-button theme="primary" @click="saveHandler">Save</idx-button>
+            </template>
+        </idx-block>
         <template #related>
-            Related Links here
+            <RelatedLinks :relatedLinks="links" />
         </template>
     </TwoColumn>
 </template>
 <script>
+import { mapState } from 'vuex'
+import { PRODUCT_REFS } from '@/data/productTerms'
 import AgentsSettings from '@/templates/AgentsSettings'
 import TwoColumn from '@/templates/layout/TwoColumn'
 import pageGuard from '@/mixins/pageGuard'
+import RelatedLinks from '@/components/RelatedLinks.vue'
 export default {
+    inject: [PRODUCT_REFS.agentSettings.repo],
     mixins: [pageGuard],
     components: {
         AgentsSettings,
+        RelatedLinks,
         TwoColumn
     },
-    created () {
+    computed: {
+        ...mapState({
+            agentSettings: (state) => state.agentSettings
+        })
+    },
+    methods: {
+        async refreshPage () {
+            const { status } = await this.agentSettingsRepository.post({ enabled: !this.agentSettings.enabled }, 'enable')
+            if (status === 200) {
+                location.reload()
+            }
+        },
+        async saveHandler () {
+            const { status } = await this.agentSettingsRepository.post(this.formChanges)
+            if (status === 200) {
+                this.saveAction()
+            }
+        }
+    },
+    async created () {
         this.module = 'agentSettings'
+        this.links = [
+            { text: 'IMPress Agents Features', href: '#' },
+            { text: 'IDX Broker Middleware', href: 'https://middleware.idxbroker.com/mgmt/' },
+            { text: 'Sign up for IDX Broker', href: 'https://signup.idxbroker.com/' } // Marketing may want a different entry
+        ]
+        const { data } = await this.agentSettingsRepository.get()
+        for (const key in data) {
+            this.$store.dispatch(`${this.module}/setItem`, { key, value: data[key] })
+        }
     }
 }
 </script>


### PR DESCRIPTION
Also:
* Made `pageGuard.js` change so dispatching `setItem` does not rely on the local action being imported into the parent component - instead, reference the module.
* Reverted to the Destructured args in `serviceContainer` so that multiple args passed (for post method) are copied over.