### PR TITLE
Wrapped Value in Array to Stop Log Notices

### DIFF
--- a/idx/shortcodes/register-shortcode-for-ui.php
+++ b/idx/shortcodes/register-shortcode-for-ui.php
@@ -35,7 +35,7 @@ class Register_Shortcode_For_Ui {
 	 * @return void
 	 */
 	public function idx_set_shortcode_preview_nonce() {
-		wp_localize_script( 'idx-shortcode', 'IDXShortcodePreviewNonce', wp_create_nonce( 'idx-shortcode-preview-nonce' ) );
+		wp_localize_script( 'idx-shortcode', 'IDXShortcodePreviewNonce', [ wp_create_nonce( 'idx-shortcode-preview-nonce' ) ] );
 	}
 
 	/**


### PR DESCRIPTION
- Resolves notice thrown in WP 5.7 about not passing an array value to wp_localize_script