### PR TITLE
Removed Old IMPress Listing Constants

### DIFF
--- a/add-ons/listings/includes/views/wp-listings-gmb-settings.php
+++ b/add-ons/listings/includes/views/wp-listings-gmb-settings.php
@@ -20,7 +20,6 @@ if ( empty( $google_my_business_options['refresh_token'] ) ) {
 		'impress-gmb-login',
 		'impressGmbAdmin',
 		[
-			'wp_resource_url'          => WP_LISTINGS_URL,
 			'nonce-gmb-initial-tokens' => wp_create_nonce( 'wpl_gmb_set_initial_tokens_nonce' ),
 		]
 	);

--- a/add-ons/listings/plugin.php
+++ b/add-ons/listings/plugin.php
@@ -12,11 +12,6 @@ function wp_listings_init() {
 
 	global $_wp_listings, $_wp_listings_taxonomies, $_wp_listings_templates;
 
-	define( 'BASE_PLUGINS_DIR', plugin_dir_path( __DIR__ ) );
-	define( 'WP_LISTINGS_URL', plugin_dir_url( __FILE__ ) );
-	define( 'WP_LISTINGS_DIR', plugin_dir_path( __FILE__ ) );
-	define( 'WP_LISTINGS_VERSION', '2.4.1' );
-
 	/** Load textdomain for translation */
 	load_plugin_textdomain( 'wp-listings', false, basename( dirname( __FILE__ ) ) . '/languages/' );
 
@@ -123,7 +118,6 @@ function wp_listings_init() {
 				'impress-gmb-settings',
 				'impressGmbAdmin',
 				[
-					'wp_resource_url'                  => WP_LISTINGS_URL,
 					'nonce-gmb-post-now'               => wp_create_nonce( 'impress_gmb_post_now_nonce' ),
 					'nonce-gmb-clear-scheduled-posts'  => wp_create_nonce( 'wpl_clear_scheduled_posts_nonce' ),
 					'nonce-gmb-get-listing-posts'      => wp_create_nonce( 'impress_gmb_get_listing_posts_nonce' ),


### PR DESCRIPTION
- Removed old constants from IMPress Listings that have been replaced by the constants created in the core plugin
- Removed remaining reference to wp_resource_url/WP_LISTINGS_URL that are no longer required