### PR TITLE
Updated Listing Template Option Checks

### DIFF
--- a/add-ons/listings/includes/listing-templates/listing-inquiry-form.php
+++ b/add-ons/listings/includes/listing-templates/listing-inquiry-form.php
@@ -1,5 +1,6 @@
 <?php
 
+add_action( 'wp_loaded', new \IDX\Shortcodes\Impress_Lead_Signup_Shortcode() );
 /**
  * Listing Inquiry Form
  * Default inquiry form for listing posts.

--- a/add-ons/listings/includes/listing-templates/single-listing-classical.php
+++ b/add-ons/listings/includes/listing-templates/single-listing-classical.php
@@ -1354,15 +1354,11 @@ function single_listing_post_content() {
 				<div id="contact-form" <?php if(!function_exists('aeprofiles_connected_agents_markup')) { echo 'style="width: 100%;"'; }; ?>>
 
 					<?php 
-					$options = get_option('plugin_wp_listings_settings');
-					if (get_post_meta( $post->ID, '_listing_contact_form', true) != '') {
-
-						echo do_shortcode(get_post_meta( $post->ID, '_listing_contact_form', true) );
-
-					} elseif (isset($options['wp_listings_default_form']) && $options['wp_listings_default_form'] != '') {
- 
-						echo do_shortcode($options['wp_listings_default_form']);
-
+					$options = get_option( 'plugin_wp_listings_settings' );
+					if ( get_post_meta( $post->ID, '_listing_contact_form', true ) != '' ) {
+						echo do_shortcode( get_post_meta( $post->ID, '_listing_contact_form', true ) );
+					} elseif ( ! empty( $options['wp_listings_default_form'] ) ) {
+						echo do_shortcode( $options['wp_listings_default_form'] );
 					} else {
 						include_once IMPRESS_IDX_DIR . 'add-ons/listings/includes/listing-templates/listing-inquiry-form.php';
 						listing_inquiry_form( $post );
@@ -1373,12 +1369,12 @@ function single_listing_post_content() {
 
 			<div id="listing-disclaimer">
 			<?php
-			if( get_post_meta($post->ID, '_listing_disclaimer', true) ) {
-				echo '<p class="wp_listings_disclaimer">' . get_post_meta($post->ID, '_listing_disclaimer', true) . '</p>';
-			} elseif ($options['wp_listings_global_disclaimer'] != '' && $options['wp_listings_global_disclaimer'] != null) {
+			if ( get_post_meta( $post->ID, '_listing_disclaimer', true ) ) {
+				echo '<p class="wp_listings_disclaimer">' . get_post_meta( $post->ID, '_listing_disclaimer', true ) . '</p>';
+			} elseif ( ! empty( $options['wp_listings_global_disclaimer'] ) ) {
 				echo '<p class="wp_listings_disclaimer">' . $options['wp_listings_global_disclaimer'] . '</p>';
 			}
-			echo (get_post_meta($post->ID, '_listing_courtesy', true)) ? '<p class="wp_listings_courtesy">' . get_post_meta($post->ID, '_listing_courtesy', true) . '</p>' : '';
+			echo ( get_post_meta( $post->ID, '_listing_courtesy', true ) ) ? '<p class="wp_listings_courtesy">' . get_post_meta( $post->ID, '_listing_courtesy', true ) . '</p>' : '';
 			?>
 			</div><!-- #listing-disclaimer -->
 		</div><!-- #listing-content .listing-data -->

--- a/add-ons/listings/includes/listing-templates/single-listing-elegant.php
+++ b/add-ons/listings/includes/listing-templates/single-listing-elegant.php
@@ -1246,14 +1246,10 @@ function single_listing_post_content() {
 				<div id="contact-form" <?php if(!function_exists('aeprofiles_connected_agents_markup')) { echo 'style="width: 100%;"'; }; ?>>
 					<?php 
 					$options = get_option('plugin_wp_listings_settings');
-					if (get_post_meta( $post->ID, '_listing_contact_form', true) != '') {
-
+					if ( get_post_meta( $post->ID, '_listing_contact_form', true ) != '' ) {
 						echo do_shortcode(get_post_meta( $post->ID, '_listing_contact_form', true) );
-
-					} elseif (isset($options['wp_listings_default_form']) && $options['wp_listings_default_form'] != '') {
- 
-						echo do_shortcode($options['wp_listings_default_form']);
-
+					} elseif ( ! empty( $options['wp_listings_default_form'] ) ) {
+						echo do_shortcode( $options['wp_listings_default_form'] );
 					} else {
 						include_once IMPRESS_IDX_DIR . 'add-ons/listings/includes/listing-templates/listing-inquiry-form.php';
 						listing_inquiry_form( $post );
@@ -1313,9 +1309,9 @@ function single_listing_post_content() {
 
 		<div id="listing-disclaimer">
 		<?php
-		if( get_post_meta($post->ID, '_listing_disclaimer', true) ) {
+		if ( get_post_meta( $post->ID, '_listing_disclaimer', true ) ) {
 			echo '<p class="wp_listings_disclaimer">' . get_post_meta($post->ID, '_listing_disclaimer', true) . '</p>';
-		} elseif ($options['wp_listings_global_disclaimer'] != '' && $options['wp_listings_global_disclaimer'] != null) {
+		} elseif ( ! empty( $options['wp_listings_global_disclaimer'] ) ) {
 			echo '<p class="wp_listings_disclaimer">' . $options['wp_listings_global_disclaimer'] . '</p>';
 		}
 		echo (get_post_meta($post->ID, '_listing_courtesy', true)) ? '<p class="wp_listings_courtesy">' . get_post_meta($post->ID, '_listing_courtesy', true) . '</p>' : '';

--- a/add-ons/listings/includes/listing-templates/single-listing-luxurious.php
+++ b/add-ons/listings/includes/listing-templates/single-listing-luxurious.php
@@ -1196,14 +1196,10 @@ function single_listing_post_content() {
 				<div id="contact-form" <?php if(!function_exists('aeprofiles_connected_agents_markup')) { echo 'style="width: 100%;"'; }; ?>>
 					<?php 
 					$options = get_option('plugin_wp_listings_settings');
-					if (get_post_meta( $post->ID, '_listing_contact_form', true) != '') {
-
-						echo do_shortcode(get_post_meta( $post->ID, '_listing_contact_form', true) );
-
-					} elseif (isset($options['wp_listings_default_form']) && $options['wp_listings_default_form'] != '') {
- 
-						echo do_shortcode($options['wp_listings_default_form']);
-
+					if ( get_post_meta( $post->ID, '_listing_contact_form', true ) != '' ) {
+						echo do_shortcode( get_post_meta( $post->ID, '_listing_contact_form', true ) );
+					} elseif ( ! empty( $options['wp_listings_default_form'] ) ) {
+						echo do_shortcode( $options['wp_listings_default_form'] );
 					} else {
 						include_once IMPRESS_IDX_DIR . 'add-ons/listings/includes/listing-templates/listing-inquiry-form.php';
 						listing_inquiry_form( $post );
@@ -1264,9 +1260,9 @@ function single_listing_post_content() {
 
 		<div id="listing-disclaimer">
 		<?php
-		if( get_post_meta($post->ID, '_listing_disclaimer', true) ) {
+		if ( get_post_meta( $post->ID, '_listing_disclaimer', true ) ) {
 			echo '<p class="wp_listings_disclaimer">' . get_post_meta($post->ID, '_listing_disclaimer', true) . '</p>';
-		} elseif ($options['wp_listings_global_disclaimer'] != '' && $options['wp_listings_global_disclaimer'] != null) {
+		} elseif ( ! empty( $options['wp_listings_global_disclaimer'] ) ) {
 			echo '<p class="wp_listings_disclaimer">' . $options['wp_listings_global_disclaimer'] . '</p>';
 		}
 		echo (get_post_meta($post->ID, '_listing_courtesy', true)) ? '<p class="wp_listings_courtesy">' . get_post_meta($post->ID, '_listing_courtesy', true) . '</p>' : '';

--- a/add-ons/listings/includes/listing-templates/single-listing-solid.php
+++ b/add-ons/listings/includes/listing-templates/single-listing-solid.php
@@ -1331,14 +1331,10 @@ function single_listing_post_content() {
 				<div id="contact-form" <?php if(!function_exists('aeprofiles_connected_agents_markup')) { echo 'style="width: 100%;"'; }; ?>>
 					<?php
 					$options = get_option('plugin_wp_listings_settings');
-					if (get_post_meta( $post->ID, '_listing_contact_form', true) != '') {
-
-						echo do_shortcode(get_post_meta( $post->ID, '_listing_contact_form', true) );
-
-					} elseif (isset($options['wp_listings_default_form']) && $options['wp_listings_default_form'] != '') {
- 
-						echo do_shortcode($options['wp_listings_default_form']);
-
+					if ( get_post_meta( $post->ID, '_listing_contact_form', true ) != '' ) {
+						echo do_shortcode( get_post_meta( $post->ID, '_listing_contact_form', true ) );
+					} elseif ( ! empty( $options['wp_listings_default_form'] ) ) {
+						echo do_shortcode( $options['wp_listings_default_form'] );
 					} else {
 						include_once IMPRESS_IDX_DIR . 'add-ons/listings/includes/listing-templates/listing-inquiry-form.php';
 						listing_inquiry_form( $post );
@@ -1351,10 +1347,10 @@ function single_listing_post_content() {
 			<?php
 			if( get_post_meta($post->ID, '_listing_disclaimer', true) ) {
 				echo '<p class="wp_listings_disclaimer">' . get_post_meta($post->ID, '_listing_disclaimer', true) . '</p>';
-			} elseif ($options['wp_listings_global_disclaimer'] != '' && $options['wp_listings_global_disclaimer'] != null) {
+			} elseif ( ! empty( $options['wp_listings_global_disclaimer'] ) ) {
 				echo '<p class="wp_listings_disclaimer">' . $options['wp_listings_global_disclaimer'] . '</p>';
 			}
-			echo (get_post_meta($post->ID, '_listing_courtesy', true)) ? '<p class="wp_listings_courtesy">' . get_post_meta($post->ID, '_listing_courtesy', true) . '</p>' : '';
+			echo ( get_post_meta( $post->ID, '_listing_courtesy', true ) ) ? '<p class="wp_listings_courtesy">' . get_post_meta( $post->ID, '_listing_courtesy', true ) . '</p>' : '';
 			?>
 			</div><!-- #listing-disclaimer -->
 

--- a/add-ons/listings/includes/listing-templates/single-listing-spacious.php
+++ b/add-ons/listings/includes/listing-templates/single-listing-spacious.php
@@ -1326,14 +1326,10 @@ function single_listing_post_content() {
 				<div id="contact-form" <?php if(!function_exists('aeprofiles_connected_agents_markup')) { echo 'style="width: 100%;"'; }; ?>>
 					<?php 
 					$options = get_option('plugin_wp_listings_settings');
-					if (get_post_meta( $post->ID, '_listing_contact_form', true) != '') {
-
-						echo do_shortcode(get_post_meta( $post->ID, '_listing_contact_form', true) );
-
-					} elseif (isset($options['wp_listings_default_form']) && $options['wp_listings_default_form'] != '') {
- 
-						echo do_shortcode($options['wp_listings_default_form']);
-
+					if ( get_post_meta( $post->ID, '_listing_contact_form', true ) != '' ) {
+						echo do_shortcode( get_post_meta( $post->ID, '_listing_contact_form', true ) );
+					} elseif ( ! empty( $options['wp_listings_default_form'] ) ) {
+						echo do_shortcode( $options['wp_listings_default_form'] );
 					} else {
 						include_once IMPRESS_IDX_DIR . 'add-ons/listings/includes/listing-templates/listing-inquiry-form.php';
 						listing_inquiry_form( $post );
@@ -1346,7 +1342,7 @@ function single_listing_post_content() {
 			<?php
 			if( get_post_meta($post->ID, '_listing_disclaimer', true) ) {
 				echo '<p class="wp_listings_disclaimer">' . get_post_meta($post->ID, '_listing_disclaimer', true) . '</p>';
-			} elseif ($options['wp_listings_global_disclaimer'] != '' && $options['wp_listings_global_disclaimer'] != null) {
+			} elseif ( ! empty( $options['wp_listings_global_disclaimer'] ) ) {
 				echo '<p class="wp_listings_disclaimer">' . $options['wp_listings_global_disclaimer'] . '</p>';
 			}
 			echo (get_post_meta($post->ID, '_listing_courtesy', true)) ? '<p class="wp_listings_courtesy">' . get_post_meta($post->ID, '_listing_courtesy', true) . '</p>' : '';


### PR DESCRIPTION
- Updated some options checks in custom listing templates as they were just checking for empty string instead of using empty()
- Explicitly adds the impress signup shortcode in the listing inquiry signup form to cover Lite accounts