### PR TITLE
IMPB-1296: Adds legacy plugin checks and deactivation logic

### DIFF
--- a/idx-broker-platinum.php
+++ b/idx-broker-platinum.php
@@ -44,11 +44,11 @@ class Idx_Broker_Plugin {
 		}
 
 		// IMPress Listings.
-		if ( boolval( get_option( 'idx_broker_listings_enabled', 0 ) ) ) {
+		if ( boolval( get_option( 'idx_broker_listings_enabled', 0 ) ) && ! is_plugin_active( 'wp-listings/plugin.php' ) ) {
 			include_once 'add-ons/listings/plugin.php';
 		}
 		// IMPress Agents.
-		if ( boolval( get_option( 'idx_broker_agents_enabled', 0 ) ) ) {
+		if ( boolval( get_option( 'idx_broker_agents_enabled', 0 ) ) && ! is_plugin_active( 'impress-agents/plugin.php' ) ) {
 			include_once 'add-ons/agents/plugin.php';
 		}
 	}
@@ -124,7 +124,7 @@ class Idx_Broker_Plugin {
 		$wrappers->register_wrapper_post_type();
 
 		// IMPress Listings.
-		if ( boolval( get_option( 'idx_broker_listings_enabled', 0 ) ) ) {
+		if ( boolval( get_option( 'idx_broker_listings_enabled', 0 ) ) && ! is_plugin_active( 'wp-listings/plugin.php' ) ) {
 			wp_listings_init();
 			global $_wp_listings, $_wp_listings_taxonomies, $_wp_listings_templates;
 			$_wp_listings->create_post_type();
@@ -137,7 +137,7 @@ class Idx_Broker_Plugin {
 		}
 
 		// IMPress Agents.
-		if ( boolval( get_option( 'idx_broker_agents_enabled', 0 ) ) ) {
+		if ( boolval( get_option( 'idx_broker_agents_enabled', 0 ) ) && ! is_plugin_active( 'impress-agents/plugin.php' ) ) {
 			impress_agents_init();
 			global $_impress_agents, $_impress_agents_taxonomies;
 			$_impress_agents->create_post_type();

--- a/idx/admin/apis/enable-addons.php
+++ b/idx/admin/apis/enable-addons.php
@@ -60,6 +60,8 @@ class Enable_Addons extends \IDX\Admin\Rest_Controller {
 	public function post( $option_name, $payload ) {
 		$enabled = (int) filter_var( $payload, FILTER_VALIDATE_BOOLEAN );
 
+		$this->deactivate_legacy_plugin( $option_name );
+
 		update_option( $option_name, $enabled );
 
 		return new \WP_REST_Response( null, 204 );
@@ -130,6 +132,21 @@ class Enable_Addons extends \IDX\Admin\Rest_Controller {
 		$output     = array_merge( $output, $beta_info );
 
 		return rest_ensure_response( $output );
+	}
+
+	/**
+	 * Deactivates legacy IMPress plugins.
+	 *
+	 * @param string $addon wp_option enabled key.
+	 * @return void
+	 */
+	private function deactivate_legacy_plugin( $addon ) {
+		if ( 'idx_broker_listings_enabled' === $addon ) {
+			deactivate_plugins( 'wp-listings/plugin.php', true );
+		}
+		if ( 'idx_broker_agents_enabled' === $addon ) {
+			deactivate_plugins( 'impress-agents/plugin.php', true );
+		}
 	}
 }
 


### PR DESCRIPTION
(This flow is the exact same for IMPress Agents)

- User has IMPress Listings installed and install IMPress for IDX 3.0.0
  - The existing IMPress Listings install works as is.
  - If the user checks 'Enable Listings' in the new IMPress for IDX dashboard
    - IMPress Listings is deactivated
    - Our consolidated version of Listings is used
- User does not have IMPress Listings installed and installs IMPress for IDX 3.0.0
  - 'Enable Listings' is unchecked
    - User can install and use the legacy IMPress Listings
  - 'Enable Listings' is checked
    - User cannot activate IMPress Listings (currently throws an error on activation, but will throw a human readable message pending IMPress Listings update)