### PR TITLE
Fix for pending idx_page duplication issue

### DIFF
--- a/idx/idx-pages.php
+++ b/idx/idx-pages.php
@@ -138,14 +138,14 @@ class Idx_Pages {
 
 		// disable ability to add new or delete IDX Pages
 		$capabilities = array(
-			'publish_posts'       => false,
+			'publish_posts'       => 'publish_idx_pages',
 			'edit_posts'          => 'edit_idx_pages',
 			'edit_others_posts'   => 'edit_others_idx_pages',
 			'delete_posts'        => false,
 			'delete_others_posts' => false,
 			'read_private_posts'  => 'read_private_idx_pages',
 			'edit_post'           => 'edit_idx_page',
-			'delete_post'         => false,
+			'delete_post'         => 'edit_idx_page',
 			'read_post'           => 'read_idx_pages',
 			'create_posts'        => false,
 		);
@@ -459,6 +459,7 @@ class Idx_Pages {
 			array(
 				'post_type'   => 'idx_page',
 				'numberposts' => -1,
+				'post_status' => 'any',
 			)
 		);
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -32,6 +32,7 @@ function idx_delete_plugin_data() {
 		array(
 			'post_type'   => 'idx_page',
 			'numberposts' => -1,
+			'post_status' => 'any',
 		)
 	);
 	foreach ( $idx_pages as $post ) {


### PR DESCRIPTION
- Resolves issue where idx_page posts are duplicated when in a non-published status
- Added ability to delete or re-publish any idx_page posts moved to draft or pending review status
- Uninstalling the plugin now correctly deletes all idx_page posts, regardless of status