### PR TITLE
Added missing default option to IMPress Lead Login widget

### DIFF
--- a/idx/widgets/impress-lead-login-widget.php
+++ b/idx/widgets/impress-lead-login-widget.php
@@ -38,12 +38,13 @@ class IMPress_Lead_Login_Widget extends \WP_Widget {
 	 * @var mixed
 	 * @access public
 	 */
-	public $defaults = array(
-		'title'       => 'Account Login',
-		'custom_text' => '',
-		'styles'      => 1,
-		'new_window'  => 0,
-	);
+	public $defaults = [
+		'title'          => 'Account Login',
+		'custom_text'    => '',
+		'styles'         => 1,
+		'new_window'     => 0,
+		'password_field' => false,
+	];
 
 	/**
 	 * Front-end display of widget.


### PR DESCRIPTION
- Added missing 'password_field' default option to prevent invalid key errors