### PR TITLE
Changed default symbol and added formatting for sold/rent price

### DIFF
--- a/idx/widgets/impress-widget-helper.php
+++ b/idx/widgets/impress-widget-helper.php
@@ -19,17 +19,17 @@ function price_selector( $property ) {
 
 	$listing_price   = empty( $property['listingPrice'] ) ? '' : $property['listingPrice'];
 	$options         = get_option( 'plugin_wp_listings_settings', 0 );
-	$currency_symbol = ( empty( $options['wp_listings_currency_symbol'] ) || 'none' === $options['wp_listings_currency_symbol'] ) ? '' : $options['wp_listings_currency_symbol'];
+	$currency_symbol = ( empty( $options['wp_listings_currency_symbol'] ) || 'none' === $options['wp_listings_currency_symbol'] ) ? '$' : $options['wp_listings_currency_symbol'];
 
 	// Supplemental listings.
 	if ( ! empty( $property['idxID'] ) && 'a999' === $property['idxID'] ) {
 		// Sold supplemental listings.
 		if ( stripos( $property['status'], 'sold' ) !== false || stripos( $property['status'], 'closed' ) !== false ) {
-			return empty( $property['soldPrice'] ) ? $listing_price : $currency_symbol . $property['soldPrice'];
+			return empty( $property['soldPrice'] ) ? $listing_price : $currency_symbol . number_format( $property['soldPrice'] );
 		}
 		// Return rntLsePrice if rntLse field is set to any value besides 'neither'.
 		if ( 'neither' !== $property['rntLse'] ) {
-			return empty( $property['rntLsePrice'] ) ? $listing_price : $currency_symbol . $property['rntLsePrice'];
+			return empty( $property['rntLsePrice'] ) ? $listing_price : $currency_symbol . number_format( $property['rntLsePrice'] );
 		}
 		// Return listing price if not sold or rental/lease.
 		return $listing_price;
@@ -40,14 +40,14 @@ function price_selector( $property ) {
 	// Active non-supplemental listings.
 	if ( ! empty( $property['idxStatus'] ) && 'active' === $property['idxStatus'] ) {
 		if ( stripos( $prop_type, 'lease' ) !== false || stripos( $prop_type, 'rent' ) !== false ) {
-			return empty( $property['rntLsePrice'] ) ? $listing_price : $property['rntLsePrice'];
+			return empty( $property['rntLsePrice'] ) ? $listing_price : $currency_symbol . number_format( $property['rntLsePrice'] );
 		}
 		return $listing_price;
 	}
 
 	// Off market non-supplemental listings.
 	if ( ! empty( $property['idxStatus'] ) && 'sold' === $property['idxStatus'] ) {
-		return empty( $property['soldPrice'] ) ? $listing_price : $currency_symbol . $property['soldPrice'];
+		return empty( $property['soldPrice'] ) ? $listing_price : $currency_symbol . number_format( $property['soldPrice'] );
 	}
 
 	return $listing_price;


### PR DESCRIPTION
- Added formatting to rent/lease price as well as sold price (while listingPrice data is formatted in the IDXB API the other prices are not)
- Changed default currency symbol from '' to '$' in the widget helper price selection function (Users that want a different symbol to be shown can do so using the currency symbol option found in the listings add-on settings)