### PR TITLE
Fix for Missing '/listings' page

### DIFF
--- a/idx/admin/apis/enable-addons.php
+++ b/idx/admin/apis/enable-addons.php
@@ -112,6 +112,7 @@ class Enable_Addons extends \IDX\Admin\Rest_Controller {
 					],
 				]
 			);
+			flush_rewrite_rules();
 		}
 	}
 


### PR DESCRIPTION
- Added flush_rewrite_rules call after activating listings or agents so users do not need to visit the permalinks page