### PR TITLE
Unscheduling Auto Import Listing Cron Job

### DIFF
--- a/add-ons/listings/includes/class-listing-import.php
+++ b/add-ons/listings/includes/class-listing-import.php
@@ -511,7 +511,7 @@ add_action( 'admin_init', 'wp_listings_idx_update_schedule' );
 
 $wpl_options = get_option( 'plugin_wp_listings_settings' );
 
-if ( isset( $wpl_options['wp_listings_auto_import'] ) && $wpl_options['wp_listings_auto_import'] == true ) {
+if ( ! empty( $wpl_options['wp_listings_auto_import'] ) ) {
 	add_action( 'admin_init', 'wp_listings_idx_auto_import_schedule' );
 }
 

--- a/idx/admin/apis/listings-idx-settings.php
+++ b/idx/admin/apis/listings-idx-settings.php
@@ -127,6 +127,10 @@ class Listings_IDX_Settings extends \IDX\Admin\Rest_Controller {
 
 		if ( isset( $payload['automaticImport'] ) ) {
 			$settings['wp_listings_auto_import'] = (int) filter_var( $payload['automaticImport'], FILTER_VALIDATE_BOOLEAN );
+			// Clear schedule if disabled.
+			if ( ! $payload['automaticImport'] ) {
+				wp_clear_scheduled_hook( 'wp_listings_idx_auto_import' );
+			}
 		}
 
 		if ( isset( $payload['defaultListingTemplateSelected'] ) ) {


### PR DESCRIPTION
Resolves issue with the auto import listings cron job still being scheduled after disabling the setting