### PR TITLE
CSS change to fix small gap at bottom of block container

### DIFF
--- a/assets/css/idx-block-edit.min.css
+++ b/assets/css/idx-block-edit.min.css
@@ -1,1 +1,1 @@
-.idx-block-placeholder-container img{width:100%}button.editor-block-list-item-idx-broker-platinum-impress-carousel-block>span>span>svg.dashicons-admin-multisite{max-width:none;max-height:none;min-width:35px;min-height:35px}
+.idx-block-placeholder-container img{width:100%;margin-bottom:-3px}button.editor-block-list-item-idx-broker-platinum-impress-carousel-block>span>span>svg.dashicons-admin-multisite{max-width:none;max-height:none;min-width:35px;min-height:35px}

--- a/src/css/idx-block-edit.css
+++ b/src/css/idx-block-edit.css
@@ -1,5 +1,6 @@
 .idx-block-placeholder-container img {
 	width: 100%;
+	margin-bottom: -3px;
 }
 
 /* Used to change the size of the size of the dashicon used for the IMPress Carousel, it is the only block not using a Font Awesome icon */


### PR DESCRIPTION
Small margin change to prevent gap from appearing when a block container is selected/active.