### PR TITLE
Update Omnibar for legacy block widget

### DIFF
--- a/idx/widgets/omnibar/idx-omnibar-widget.php
+++ b/idx/widgets/omnibar/idx-omnibar-widget.php
@@ -80,6 +80,8 @@ class IDX_Omnibar_Widget extends \WP_Widget {
 	 * @return void
 	 */
 	public function update( $new_instance, $old_instance ) {
+		// Merge defaults and new_instance to avoid any missing index warnings when used with the legacy block widget.
+		$new_instance          = array_merge( $this->defaults, $new_instance );
 		$instance              = $old_instance;
 		$instance['title']     = $new_instance['title'];
 		$instance['styles']    = (int) $new_instance['styles'];


### PR DESCRIPTION
Applies widget defaults to $new_instance to prevent missing key warnings from being thrown when using the legacy block widget