### PR TITLE
Consolidated get agent select list functions

### DIFF
--- a/idx/idx-api.php
+++ b/idx/idx-api.php
@@ -997,7 +997,7 @@ class Idx_Api {
 	public function get_agents_select_list( $agent_id ) {
 		$agents_array = $this->idx_api( 'agents', IDX_API_DEFAULT_VERSION, 'clients', array(), 7200, 'GET', true );
 
-		if ( ! is_array( $agents_array ) || ! isset( $agents_array['agent'] ) ) {
+		if ( empty( $agents_array['agent'] ) ) {
 			return;
 		}
 

--- a/idx/register-blocks.php
+++ b/idx/register-blocks.php
@@ -799,7 +799,7 @@ class Register_Blocks {
 
 		if ( get_option( 'idx_broker_apikey' ) ) {
 			$agent_api_data = $this->idx_api->idx_api( 'agents', IDX_API_DEFAULT_VERSION, 'clients', array(), 7200, 'GET', true );
-			if ( $agent_api_data['agent'] ) {
+			if ( ! empty( $agent_api_data['agent'] ) ) {
 				foreach ( $agent_api_data['agent'] as $current_agent ) {
 					array_push( $agents_list, [ 'label' => $current_agent['agentDisplayName'], 'value' => $current_agent['agentID'] ] );
 				}

--- a/idx/shortcodes/register-shortcode-for-ui.php
+++ b/idx/shortcodes/register-shortcode-for-ui.php
@@ -425,7 +425,7 @@ class Register_Shortcode_For_Ui {
 		$output .= "<div class=\"idx-modal-shortcode-field\" data-shortcode=\"$shortcode\">";
 		$output .= '<label for"agent_id">Route to Agent:</label>';
 		$output .= '<select id="agent_id" data-short-name="agent_id">';
-		$output .= $this->get_agents_select_list( $defaults['agent_id'] );
+		$output .= $this->idx_api->get_agents_select_list( $defaults['agent_id'] );
 		$output .= '</select>';
 		$output .= '</div>';
 
@@ -559,7 +559,7 @@ class Register_Shortcode_For_Ui {
 		$output .= "<div class=\"idx-modal-shortcode-field\" data-shortcode=\"$shortcode\">";
 		$output .= '<label for"agent_id">Limit by Agent:</label>';
 		$output .= '<select id="agent_id" data-short-name="agent_id">';
-		$output .= $this->get_agents_select_list( $defaults['agent_id'] );
+		$output .= $this->idx_api->get_agents_select_list( $defaults['agent_id'] );
 		$output .= '</select>';
 		$output .= '</div>';
 
@@ -666,7 +666,7 @@ class Register_Shortcode_For_Ui {
 		$output .= "<div class=\"idx-modal-shortcode-field\" data-shortcode=\"$shortcode\">";
 		$output .= '<label for"agent_id">Limit by Agent:</label>';
 		$output .= '<select id="agent_id" data-short-name="agent_id">';
-		$output .= $this->get_agents_select_list( $defaults['agent_id'] );
+		$output .= $this->idx_api->get_agents_select_list( $defaults['agent_id'] );
 		$output .= '</select>';
 		$output .= '</div>';
 
@@ -722,33 +722,4 @@ class Register_Shortcode_For_Ui {
 		return $output;
 	}
 
-
-	/**
-	 * get_agents_select_list function.
-	 *
-	 * @access public
-	 * @param mixed $agent_id
-	 * @return void
-	 */
-	public function get_agents_select_list( $agent_id ) {
-		$agents_array = $this->idx_api->idx_api( 'agents', IDX_API_DEFAULT_VERSION, 'clients', array(), 7200, 'GET', true );
-
-		if ( ! is_array( $agents_array ) ) {
-			return;
-		}
-
-		if ( $agent_id != null ) {
-			$agents_list = '<option value="" ' . selected( $agent_id, '', '' ) . '>Use default routing</option>';
-			foreach ( $agents_array['agent'] as $agent ) {
-				$agents_list .= '<option value="' . $agent['agentID'] . '" ' . selected( $agent_id, $agent['agentID'], 0 ) . '>' . $agent['agentDisplayName'] . '</option>';
-			}
-		} else {
-			$agents_list = '<option value="">All</option>';
-			foreach ( $agents_array['agent'] as $agent ) {
-				$agents_list .= '<option value="' . $agent['agentID'] . '">' . $agent['agentDisplayName'] . '</option>';
-			}
-		}
-
-		return $agents_list;
-	}
 }

--- a/idx/widgets/impress-carousel-widget.php
+++ b/idx/widgets/impress-carousel-widget.php
@@ -490,7 +490,7 @@ class Impress_Carousel_Widget extends \WP_Widget {
 		<p>
 			<label for="<?php echo $this->get_field_id( 'agentID' ); ?>"><?php _e( 'Limit by Agent:', 'idxbroker' ); ?></label>
 			<select class="widefat" id="<?php echo $this->get_field_id( 'agentID' ); ?>" name="<?php echo $this->get_field_name( 'agentID' ); ?>">
-				<?php echo $this->get_agents_select_list( $instance['agentID'] ); ?>
+				<?php echo $this->idx_api->get_agents_select_list( $instance['agentID'] ); ?>
 			</select>
 		</p>
 
@@ -534,34 +534,6 @@ class Impress_Carousel_Widget extends \WP_Widget {
 		</p>
 
 		<?php
-	}
-
-	/**
-	 * Returns agents wrapped in option tags
-	 *
-	 * @param  int $agent_id Instance agentID if exists.
-	 * @return string HTML options tags of agents ids and names.
-	 */
-	public function get_agents_select_list( $agent_id ) {
-		$agents_array = $this->idx_api->idx_api( 'agents', IDX_API_DEFAULT_VERSION, 'clients', array(), 7200, 'GET', true );
-
-		if ( ! is_array( $agents_array ) ) {
-			return;
-		}
-
-		if ( $agent_id != null ) {
-			$agents_list = '<option value="" ' . selected( $agent_id, '', '' ) . '>All</option>';
-			foreach ( $agents_array['agent'] as $agent ) {
-				$agents_list .= '<option value="' . $agent['agentID'] . '" ' . selected( $agent_id, $agent['agentID'], 0 ) . '>' . $agent['agentDisplayName'] . '</option>';
-			}
-		} else {
-			$agents_list = '<option value="">All</option>';
-			foreach ( $agents_array['agent'] as $agent ) {
-				$agents_list .= '<option value="' . $agent['agentID'] . '">' . $agent['agentDisplayName'] . '</option>';
-			}
-		}
-
-		return $agents_list;
 	}
 
 	/**

--- a/idx/widgets/impress-lead-signup-widget.php
+++ b/idx/widgets/impress-lead-signup-widget.php
@@ -260,7 +260,7 @@ class Impress_Lead_Signup_Widget extends \WP_Widget {
 		<p>
 			<label for="<?php echo $this->get_field_id( 'agentID' ); ?>"><?php _e( 'Route to Agent:', 'idxbroker' ); ?></label>
 			<select class="widefat" id="<?php echo $this->get_field_id( 'agentID' ); ?>" name="<?php echo $this->get_field_name( 'agentID' ); ?>">
-				<?php echo $this->get_agents_select_list( $instance['agentID'] ); ?>
+				<?php echo $this->idx_api->get_agents_select_list( $instance['agentID'] ); ?>
 			</select>
 		</p>
 		<p>
@@ -314,31 +314,4 @@ class Impress_Lead_Signup_Widget extends \WP_Widget {
 		return $output;
 	}
 
-	/**
-	 * Returns agents wrapped in option tags
-	 *
-	 * @param  int $agent_id Instance agentID if exists.
-	 * @return string HTML options tags of agents ids and names.
-	 */
-	public function get_agents_select_list( $agent_id ) {
-		$agents_array = $this->idx_api->idx_api( 'agents', IDX_API_DEFAULT_VERSION, 'clients', array(), 7200, 'GET', true );
-
-		if ( ! is_array( $agents_array ) ) {
-			return;
-		}
-
-		if ( $agent_id != null ) {
-			$agents_list = '<option value="" ' . selected( $agent_id, '', '' ) . '>All</option>';
-			foreach ( $agents_array['agent'] as $agent ) {
-				$agents_list .= '<option value="' . $agent['agentID'] . '" ' . selected( $agent_id, $agent['agentID'], 0 ) . '>' . $agent['agentDisplayName'] . '</option>';
-			}
-		} else {
-			$agents_list = '<option value="">All</option>';
-			foreach ( $agents_array['agent'] as $agent ) {
-				$agents_list .= '<option value="' . $agent['agentID'] . '">' . $agent['agentDisplayName'] . '</option>';
-			}
-		}
-
-		return $agents_list;
-	}
 }

--- a/idx/widgets/impress-showcase-widget.php
+++ b/idx/widgets/impress-showcase-widget.php
@@ -554,7 +554,7 @@ class Impress_Showcase_Widget extends \WP_Widget {
 		<p>
 			<label for="<?php echo $this->get_field_id( 'agentID' ); ?>"><?php _e( 'Limit by Agent:', 'idxbroker' ); ?></label>
 			<select class="widefat" id="<?php echo $this->get_field_id( 'agentID' ); ?>" name="<?php echo $this->get_field_name( 'agentID' ); ?>">
-				<?php echo $this->get_agents_select_list( $instance['agentID'] ); ?>
+				<?php echo $this->idx_api->get_agents_select_list( $instance['agentID'] ); ?>
 			</select>
 		</p>
 
@@ -607,34 +607,6 @@ class Impress_Showcase_Widget extends \WP_Widget {
 		</p>
 
 		<?php
-	}
-
-	/**
-	 * Returns agents wrapped in option tags
-	 *
-	 * @param int $agent_id - Instance agentID if exists.
-	 * @return mixed HTML options tags of agents ids and names.
-	 */
-	public function get_agents_select_list( $agent_id ) {
-		$agents_array = $this->idx_api->idx_api( 'agents', IDX_API_DEFAULT_VERSION, 'clients', array(), 7200, 'GET', true );
-
-		if ( ! is_array( $agents_array ) ) {
-			return;
-		}
-
-		if ( $agent_id != null ) {
-			$agents_list = '<option value="" ' . selected( $agent_id, '', '' ) . '>All</option>';
-			foreach ( $agents_array['agent'] as $agent ) {
-				$agents_list .= '<option value="' . $agent['agentID'] . '" ' . selected( $agent_id, $agent['agentID'], 0 ) . '>' . $agent['agentDisplayName'] . '</option>';
-			}
-		} else {
-			$agents_list = '<option value="">All</option>';
-			foreach ( $agents_array['agent'] as $agent ) {
-				$agents_list .= '<option value="' . $agent['agentID'] . '">' . $agent['agentDisplayName'] . '</option>';
-			}
-		}
-
-		return $agents_list;
 	}
 
 	/**


### PR DESCRIPTION
- Changed check on the get_agents_select_list() function found in idx_api.php to prevent missing key warnings when access ing 'agent'
- Removed duplicate versions of get_agents_select_list() functions from various widget files. Those files already have an instance of idx_api so they have access to the function from there
- Updated key check in agent select list function in the block registration file (this version was not consolidated as it returns just the agent data to be used with the block editor instead of <option> elements used by the legacy widgets)