### PR TITLE
Status field fallback for price_selector helper function 

### DIFF
--- a/idx/widgets/impress-widget-helper.php
+++ b/idx/widgets/impress-widget-helper.php
@@ -24,7 +24,8 @@ function price_selector( $property ) {
 	// Supplemental listings.
 	if ( ! empty( $property['idxID'] ) && 'a999' === $property['idxID'] ) {
 		// Sold supplemental listings.
-		if ( stripos( $property['status'], 'sold' ) !== false || stripos( $property['status'], 'closed' ) !== false ) {
+		$status = $property['status'] ?? $property['idxStatus'] ?? '';
+		if ( stripos( $status, 'sold' ) !== false || stripos( $status, 'closed' ) !== false ) {
 			return empty( $property['soldPrice'] ) ? $listing_price : $currency_symbol . number_format( $property['soldPrice'] );
 		}
 		// Return rntLsePrice if rntLse field is set to any value besides 'neither'.


### PR DESCRIPTION
Added 'idxStatus' as fallback for 'status' field to avoid log errors as some sold supplemental listings have one field set but not the other.