### PR TITLE
Added Convenience Method to IDX API Class for Saved Link Listing Count

### DIFF
--- a/idx/idx-api.php
+++ b/idx/idx-api.php
@@ -573,6 +573,22 @@ class Idx_Api {
 	}
 
 	/**
+	 * Saved_link_properties_count function.
+	 * Used to get accurate count on saved link results as the /results method currently is limited to 250 listings returned.
+	 *
+	 * @access public
+	 * @param mixed $saved_link_id - Saved link ID.
+	 * @return mixed
+	 */
+	public function saved_link_properties_count( $saved_link_id ) {
+		$saved_link_count = $this->idx_api( 'savedlinks/' . $saved_link_id . '/count', IDX_API_DEFAULT_VERSION, 'clients', array(), 7200, 'GET', true );
+		if ( is_wp_error( $saved_link_count ) || empty( $saved_link_count[0] ) ) {
+			return 0;
+		}
+		return $saved_link_count[0];
+	}
+
+	/**
 	 * Client_properties function.
 	 * Expected $type posibilities: featured, soldpending, supplemental.
 	 * 

--- a/idx/widgets/impress-widget-helper.php
+++ b/idx/widgets/impress-widget-helper.php
@@ -24,7 +24,8 @@ function price_selector( $property ) {
 	// Supplemental listings.
 	if ( ! empty( $property['idxID'] ) && 'a999' === $property['idxID'] ) {
 		// Sold supplemental listings.
-		if ( stripos( $property['status'], 'sold' ) !== false || stripos( $property['status'], 'closed' ) !== false ) {
+		$status = $property['status'] ?? $property['idxStatus'] ?? '';
+		if ( stripos( $status, 'sold' ) !== false || stripos( $status, 'closed' ) !== false ) {
 			return empty( $property['soldPrice'] ) ? $listing_price : $currency_symbol . number_format( $property['soldPrice'] );
 		}
 		// Return rntLsePrice if rntLse field is set to any value besides 'neither'.

--- a/idx/widgets/impress-widget-helper.php
+++ b/idx/widgets/impress-widget-helper.php
@@ -24,8 +24,7 @@ function price_selector( $property ) {
 	// Supplemental listings.
 	if ( ! empty( $property['idxID'] ) && 'a999' === $property['idxID'] ) {
 		// Sold supplemental listings.
-		$status = $property['status'] ?? $property['idxStatus'] ?? '';
-		if ( stripos( $status, 'sold' ) !== false || stripos( $status, 'closed' ) !== false ) {
+		if ( stripos( $property['status'], 'sold' ) !== false || stripos( $property['status'], 'closed' ) !== false ) {
 			return empty( $property['soldPrice'] ) ? $listing_price : $currency_symbol . number_format( $property['soldPrice'] );
 		}
 		// Return rntLsePrice if rntLse field is set to any value besides 'neither'.


### PR DESCRIPTION
Added method to IDX API class to get listings count from a saved link ID. Currently the API limits returned saved link results to 250 listings so savedlinks/{link_id}/count must be used instead to get the real number of results. 