### PR TITLE
IMPB-1429 - Fix encoded html text from displaying

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 👋 Hello there! Welcome. Please follow the steps below to tell us about your contribution.
 
-Please exaplin the intent of your Pull Request.
+Please explain the intent of your Pull Request.
 
 🐛 Are you fixing a bug?
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ For users with IMPress 3.0 who have legacy versions of IMPress Listings and/or I
 ### 3.0.8 ###
 * Fix: Some additional sanitization and escaping added that was missed in 3.0.7
 * Update: Moved externally hosted CSS file into the plugin
-* Update: Bootstrap.js version used for the listing templates "Solid" and "Classical" was bumptetd from 3.1.1 to 5.1.3
+* Update: Bootstrap.js version used for the listing templates "Solid" and "Classical" was bumped from 3.1.1 to 5.1.3
 
 ### 3.0.7 ###
 * Fix: Large scale security overhaul including sanitization/escaping and removal of any PHP eval() usage

--- a/add-ons/agents/includes/class-employee-widget.php
+++ b/add-ons/agents/includes/class-employee-widget.php
@@ -87,7 +87,7 @@ class IMPress_Agents_Widget extends WP_Widget {
 
 		if ( have_posts() ) : while ( have_posts() ) : the_post();
 
-				echo '<div ' . esc_attr( post_class( 'widget-agent-wrap' ) ) . '>';
+				echo '<div ', esc_attr( post_class( 'widget-agent-wrap' ) ), '>';
 				echo '<a href="' . esc_url( get_permalink() ) . '">', get_the_post_thumbnail( $post->ID, 'employee-thumbnail' ), '</a>';
 				printf( '<div class="widget-agent-details"><a class="fn" href="%s">%s</a>', esc_url( get_permalink() ), esc_html( get_the_title() ) );
 				impa_employee_archive_details();

--- a/add-ons/listings/includes/class-featured-listings-widget.php
+++ b/add-ons/listings/includes/class-featured-listings-widget.php
@@ -104,7 +104,7 @@ class WP_Listings_Featured_Listings_Widget extends WP_Widget {
 				$loop .= sprintf( '<div class="listing-thumb-meta">' );
 
 				if ( '' != get_post_meta( $post->ID, '_listing_text', true ) ) {
-					$loop .= sprintf( '<span class="listing-text">%s</span>', get_post_meta( $post->ID, esc_html('_listing_text'), true ) );
+					$loop .= sprintf( '<span class="listing-text">%s</span>', get_post_meta( $post->ID, '_listing_text', true ) );
 				} elseif ( '' != wp_listings_get_property_types() ) {
 					$loop .= sprintf( '<span class="listing-property-type">%s</span>', wp_listings_get_property_types() );
 				}
@@ -113,21 +113,21 @@ class WP_Listings_Featured_Listings_Widget extends WP_Widget {
 					$currency_symbol = ( empty( $options['wp_listings_currency_symbol'] ) || 'none' === $options['wp_listings_currency_symbol'] ) ? '' : $options['wp_listings_currency_symbol'];
 					$currency_code   = ( ! empty( $options['wp_listings_display_currency_code'] ) && ! empty( $options['wp_listings_display_currency_code'] && $options['wp_listings_currency_code'] !== 'none' ) ) ? '<span class="currency-code">' . $options['wp_listings_currency_code'] . '</span>' : '';
 					$loop           .= '<style>.currency-symbol:empty{display:none!important;}</style>';
-					$loop           .= sprintf( '<span class="listing-price"><span class="currency-symbol" style="">%s</span>%s %s</span>', $currency_symbol, get_post_meta( $post->ID, esc_html('_listing_price'), true ), $currency_code );
+					$loop           .= sprintf( '<span class="listing-price"><span class="currency-symbol" style="">%s</span>%s %s</span>', $currency_symbol, get_post_meta( $post->ID, '_listing_price', true ), $currency_code );
 				}
 
 				$loop .= sprintf( '</div><!-- .listing-thumb-meta --></div><!-- .listing-widget-thumb -->' );
 
 				if ( '' != get_post_meta( $post->ID, '_listing_open_house', true ) ) {
-					$loop .= sprintf( '<span class="listing-open-house">Open House: %s</span>', get_post_meta( $post->ID, esc_html('_listing_open_house'), true ) );
+					$loop .= sprintf( '<span class="listing-open-house">Open House: %s</span>', get_post_meta( $post->ID, '_listing_open_house', true ) );
 				}
 
 				$loop .= sprintf( '<div class="listing-widget-details"><h3 class="listing-title"><a href="%s">%s</a></h3>', get_permalink(), get_the_title() );
 				$loop .= sprintf( '<p class="listing-address"><span class="listing-address">%s</span><br />', wp_listings_get_address() );
-				$loop .= sprintf( '<span class="listing-city-state-zip">%s, %s %s</span></p>', wp_listings_get_city(), wp_listings_get_state(), get_post_meta( $post->ID, esc_html('_listing_zip'), true ) );
+				$loop .= sprintf( '<span class="listing-city-state-zip">%s, %s %s</span></p>', wp_listings_get_city(), wp_listings_get_state(), get_post_meta( $post->ID, '_listing_zip', true ) );
 
 				if ( '' != get_post_meta( $post->ID, '_listing_bedrooms', true ) || '' != get_post_meta( $post->ID, '_listing_bathrooms', true ) || '' != get_post_meta( $post->ID, '_listing_sqft', true )) {
-					$loop .= sprintf( '<ul class="listing-beds-baths-sqft"><li class="beds">%s<span>Beds</span></li> <li class="baths">%s<span>Baths</span></li> <li class="sqft">%s<span>Sq ft</span></li></ul>', get_post_meta( $post->ID, '_listing_bedrooms', true ), get_post_meta( $post->ID, esc_html('_listing_bathrooms'), true ), get_post_meta( $post->ID, esc_html('_listing_sqft'), true ) );
+					$loop .= sprintf( '<ul class="listing-beds-baths-sqft"><li class="beds">%s<span>Beds</span></li> <li class="baths">%s<span>Baths</span></li> <li class="sqft">%s<span>Sq ft</span></li></ul>', get_post_meta( $post->ID, '_listing_bedrooms', true ), get_post_meta( $post->ID, '_listing_bathrooms', true ), get_post_meta( $post->ID, '_listing_sqft', true ) );
 				}
 
 				$loop .= sprintf( '</div><!-- .listing-widget-details -->' );

--- a/add-ons/listings/includes/class-featured-listings-widget.php
+++ b/add-ons/listings/includes/class-featured-listings-widget.php
@@ -104,7 +104,7 @@ class WP_Listings_Featured_Listings_Widget extends WP_Widget {
 				$loop .= sprintf( '<div class="listing-thumb-meta">' );
 
 				if ( '' != get_post_meta( $post->ID, '_listing_text', true ) ) {
-					$loop .= sprintf( '<span class="listing-text">%s</span>', get_post_meta( $post->ID, '_listing_text', true ) );
+					$loop .= sprintf( '<span class="listing-text">%s</span>', esc_html( get_post_meta( $post->ID, '_listing_text', true ) ) );
 				} elseif ( '' != wp_listings_get_property_types() ) {
 					$loop .= sprintf( '<span class="listing-property-type">%s</span>', wp_listings_get_property_types() );
 				}
@@ -113,7 +113,7 @@ class WP_Listings_Featured_Listings_Widget extends WP_Widget {
 					$currency_symbol = ( empty( $options['wp_listings_currency_symbol'] ) || 'none' === $options['wp_listings_currency_symbol'] ) ? '' : $options['wp_listings_currency_symbol'];
 					$currency_code   = ( ! empty( $options['wp_listings_display_currency_code'] ) && ! empty( $options['wp_listings_display_currency_code'] && $options['wp_listings_currency_code'] !== 'none' ) ) ? '<span class="currency-code">' . $options['wp_listings_currency_code'] . '</span>' : '';
 					$loop           .= '<style>.currency-symbol:empty{display:none!important;}</style>';
-					$loop           .= sprintf( '<span class="listing-price"><span class="currency-symbol" style="">%s</span>%s %s</span>', $currency_symbol, get_post_meta( $post->ID, '_listing_price', true ), $currency_code );
+					$loop           .= sprintf( '<span class="listing-price"><span class="currency-symbol" style="">%s</span>%s %s</span>', $currency_symbol, esc_html( get_post_meta( $post->ID, '_listing_price', true ) ), $currency_code );
 				}
 
 				$loop .= sprintf( '</div><!-- .listing-thumb-meta --></div><!-- .listing-widget-thumb -->' );
@@ -123,11 +123,11 @@ class WP_Listings_Featured_Listings_Widget extends WP_Widget {
 				}
 
 				$loop .= sprintf( '<div class="listing-widget-details"><h3 class="listing-title"><a href="%s">%s</a></h3>', get_permalink(), get_the_title() );
-				$loop .= sprintf( '<p class="listing-address"><span class="listing-address">%s</span><br />', wp_listings_get_address() );
-				$loop .= sprintf( '<span class="listing-city-state-zip">%s, %s %s</span></p>', wp_listings_get_city(), wp_listings_get_state(), get_post_meta( $post->ID, '_listing_zip', true ) );
+				$loop .= sprintf( '<p class="listing-address"><span class="listing-address">%s</span><br />', esc_html( wp_listings_get_address() ) );
+				$loop .= sprintf( '<span class="listing-city-state-zip">%s, %s %s</span></p>', esc_html( wp_listings_get_city() ), esc_html( wp_listings_get_state() ), get_post_meta( $post->ID, '_listing_zip', true ) );
 
 				if ( '' != get_post_meta( $post->ID, '_listing_bedrooms', true ) || '' != get_post_meta( $post->ID, '_listing_bathrooms', true ) || '' != get_post_meta( $post->ID, '_listing_sqft', true )) {
-					$loop .= sprintf( '<ul class="listing-beds-baths-sqft"><li class="beds">%s<span>Beds</span></li> <li class="baths">%s<span>Baths</span></li> <li class="sqft">%s<span>Sq ft</span></li></ul>', get_post_meta( $post->ID, '_listing_bedrooms', true ), get_post_meta( $post->ID, '_listing_bathrooms', true ), get_post_meta( $post->ID, '_listing_sqft', true ) );
+					$loop .= sprintf( '<ul class="listing-beds-baths-sqft"><li class="beds">%s<span>Beds</span></li> <li class="baths">%s<span>Baths</span></li> <li class="sqft">%s<span>Sq ft</span></li></ul>', esc_html( get_post_meta( $post->ID, '_listing_bedrooms', true ) ) , esc_html( get_post_meta( $post->ID, '_listing_bathrooms', true ) ), esc_html( get_post_meta( $post->ID, '_listing_sqft', true ) ) );
 				}
 
 				$loop .= sprintf( '</div><!-- .listing-widget-details -->' );

--- a/add-ons/listings/includes/class-featured-listings-widget.php
+++ b/add-ons/listings/includes/class-featured-listings-widget.php
@@ -104,7 +104,7 @@ class WP_Listings_Featured_Listings_Widget extends WP_Widget {
 				$loop .= sprintf( '<div class="listing-thumb-meta">' );
 
 				if ( '' != get_post_meta( $post->ID, '_listing_text', true ) ) {
-					$loop .= sprintf( '<span class="listing-text">%s</span>', get_post_meta( $post->ID, '_listing_text', true ) );
+					$loop .= sprintf( '<span class="listing-text">%s</span>', get_post_meta( $post->ID, esc_html('_listing_text'), true ) );
 				} elseif ( '' != wp_listings_get_property_types() ) {
 					$loop .= sprintf( '<span class="listing-property-type">%s</span>', wp_listings_get_property_types() );
 				}
@@ -113,21 +113,21 @@ class WP_Listings_Featured_Listings_Widget extends WP_Widget {
 					$currency_symbol = ( empty( $options['wp_listings_currency_symbol'] ) || 'none' === $options['wp_listings_currency_symbol'] ) ? '' : $options['wp_listings_currency_symbol'];
 					$currency_code   = ( ! empty( $options['wp_listings_display_currency_code'] ) && ! empty( $options['wp_listings_display_currency_code'] && $options['wp_listings_currency_code'] !== 'none' ) ) ? '<span class="currency-code">' . $options['wp_listings_currency_code'] . '</span>' : '';
 					$loop           .= '<style>.currency-symbol:empty{display:none!important;}</style>';
-					$loop           .= sprintf( '<span class="listing-price"><span class="currency-symbol" style="">%s</span>%s %s</span>', $currency_symbol, get_post_meta( $post->ID, '_listing_price', true ), $currency_code );
+					$loop           .= sprintf( '<span class="listing-price"><span class="currency-symbol" style="">%s</span>%s %s</span>', $currency_symbol, get_post_meta( $post->ID, esc_html('_listing_price'), true ), $currency_code );
 				}
 
 				$loop .= sprintf( '</div><!-- .listing-thumb-meta --></div><!-- .listing-widget-thumb -->' );
 
 				if ( '' != get_post_meta( $post->ID, '_listing_open_house', true ) ) {
-					$loop .= sprintf( '<span class="listing-open-house">Open House: %s</span>', get_post_meta( $post->ID, '_listing_open_house', true ) );
+					$loop .= sprintf( '<span class="listing-open-house">Open House: %s</span>', get_post_meta( $post->ID, esc_html('_listing_open_house'), true ) );
 				}
 
 				$loop .= sprintf( '<div class="listing-widget-details"><h3 class="listing-title"><a href="%s">%s</a></h3>', get_permalink(), get_the_title() );
 				$loop .= sprintf( '<p class="listing-address"><span class="listing-address">%s</span><br />', wp_listings_get_address() );
-				$loop .= sprintf( '<span class="listing-city-state-zip">%s, %s %s</span></p>', wp_listings_get_city(), wp_listings_get_state(), get_post_meta( $post->ID, '_listing_zip', true ) );
+				$loop .= sprintf( '<span class="listing-city-state-zip">%s, %s %s</span></p>', wp_listings_get_city(), wp_listings_get_state(), get_post_meta( $post->ID, esc_html('_listing_zip'), true ) );
 
 				if ( '' != get_post_meta( $post->ID, '_listing_bedrooms', true ) || '' != get_post_meta( $post->ID, '_listing_bathrooms', true ) || '' != get_post_meta( $post->ID, '_listing_sqft', true )) {
-					$loop .= sprintf( '<ul class="listing-beds-baths-sqft"><li class="beds">%s<span>Beds</span></li> <li class="baths">%s<span>Baths</span></li> <li class="sqft">%s<span>Sq ft</span></li></ul>', get_post_meta( $post->ID, '_listing_bedrooms', true ), get_post_meta( $post->ID, '_listing_bathrooms', true ), get_post_meta( $post->ID, '_listing_sqft', true ) );
+					$loop .= sprintf( '<ul class="listing-beds-baths-sqft"><li class="beds">%s<span>Beds</span></li> <li class="baths">%s<span>Baths</span></li> <li class="sqft">%s<span>Sq ft</span></li></ul>', get_post_meta( $post->ID, '_listing_bedrooms', true ), get_post_meta( $post->ID, esc_html('_listing_bathrooms'), true ), get_post_meta( $post->ID, esc_html('_listing_sqft'), true ) );
 				}
 
 				$loop .= sprintf( '</div><!-- .listing-widget-details -->' );
@@ -135,7 +135,7 @@ class WP_Listings_Featured_Listings_Widget extends WP_Widget {
 				$loop .= sprintf( '<a href="%s" class="button btn-primary more-link">%s</a>', esc_url( get_permalink() ), __( 'View Listing', 'wp-listings' ) );
 
 				// wrap in div with possible column class, and output.
-				printf( '<div class="listing %s post-%s"><div class="listing-wrap">%s</div></div>', esc_attr( $column_class . $first_class ), esc_attr( $post->ID ), esc_html( apply_filters( 'wp_listings_featured_listings_widget_loop', $loop ) ) );
+				printf( '<div class="listing %s post-%s"><div class="listing-wrap">%s</div></div>', esc_attr( $column_class . $first_class ), esc_attr( $post->ID ), apply_filters( 'wp_listings_featured_listings_widget_loop', $loop ) );
 
 			}
 		}


### PR DESCRIPTION
### Description

1.  Fixed a bug where the widget was being returned encoded HTML rather than raw HTML resulting in <div class="...... displaying on the site, rather than the widget. #409 
2.  Fixed a typo in this pull request template


### Verification Process

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
-- Edited widget in WP editor. Added a console.log script in various places of a listing and added esc_html earlier in the widget function where data is being added rather than at the end when the widget is being outputted.

- How did you verify that all changed functionality works as expected?
-- Widget functioned as expected and malicious scripts that I added (the console.logs) were displayed instead of run

- How did you verify that the change has not introduced any regressions?
-- The widget now works better than it did in 3.0.6 because scripts will not run from listings addresses etc.  Downloaded 3.0.6 and compared widget displays and they look the same except that now scripts are escaped

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

1. Using Beaver Builder, added IMPress Listings Featured Showcase to the homepage. Widget displays as expected
2. Navigate to Listings > edit a listing
3. Add `<script>console.log("esc_html did not function for $fieldName")</script>` to various fields that display through the widget (price, address, city). Update listing
4. Refresh homepage, check for console.logs - no messages logged, script texts displaying on the widget


### Release Notes

Fixed Listings showcase bug where HTML was displaying rather than the widget.


## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
