### PR TITLE
Typo in function name cause fatal error

### DIFF
--- a/idx/widgets/impress-lead-signup-widget.php
+++ b/idx/widgets/impress-lead-signup-widget.php
@@ -14,7 +14,7 @@ class Impress_Lead_Signup_Widget extends \WP_Widget {
 		$this->idx_api = new \IDX\Idx_Api();
 
 		if ( isset( $_GET['error'] ) ) {
-			$this->error_message = $this->handle_errors( (string) sanatize_text_field( wp_unslash( $_GET['error'] ) ) );
+			$this->error_message = $this->handle_errors( (string) sanitize_text_field( wp_unslash( $_GET['error'] ) ) );
 		} else {
 			$this->error_message = '';
 		}


### PR DESCRIPTION
Only 1 instance of `sanatize_text_field` in the whole repository, which is causing an fatal error in some cases

There are 105 instances of `sanitize_text_field`. 


```
 Fatal error: Uncaught Error: Call to undefined function IDX\Widgets\sanatize_text_field()
in /www/wp-content/plugins/idx-broker-platinum/idx/widgets/impress-lead-signup-widget.php on line 17

Call stack:

    IDX\W\Impress_Lead_Signup_Widget::__construct()
    wp-includes/class-wp-widget-factory.php:61
    WP_Widget_Factory::register()
    wp-includes/widgets.php:115
    register_widget()
    wp-content/plugins/idx-broker-platinum/idx/widgets/create-impress-widgets.php:43
    IDX\W\Create_Impress_Widgets::register_impress_widgets()
    wp-includes/class-wp-hook.php:303
    WP_Hook::apply_filters()
    wp-includes/class-wp-hook.php:327
    WP_Hook::do_action()
    wp-includes/plugin.php:470
    do_action()
    wp-includes/widgets.php:1809
    wp_widgets_init()
    wp-includes/class-wp-hook.php:303
    WP_Hook::apply_filters()
    wp-includes/class-wp-hook.php:327
    WP_Hook::do_action()
    wp-includes/plugin.php:470
    do_action()
    wp-settings.php:581
    require_once()
    wp-config.php:91
    require_once()
    wp-load.php:50
    require_once()
    wp-admin/admin.php:34
    require_once()
    wp-admin/plugins.php:10
```