### PR TITLE
Rename 'google-recaptcha' wp_enqueue_script to 'idx-google-recaptcha'…

### DIFF
--- a/idx/initiate-plugin.php
+++ b/idx/initiate-plugin.php
@@ -510,7 +510,7 @@ class Initiate_Plugin {
 		wp_register_script( 'dialog-polyfill', IMPRESS_IDX_URL . 'assets/js/dialog-polyfill.js', [], '1.0.0', false );
 		wp_register_script( 'impress-lead-signup', IMPRESS_IDX_URL . 'assets/js/idx-lead-signup.min.js', [], '1.0.0', false );
 		wp_register_script( 'idx-recaptcha', IMPRESS_IDX_URL . 'assets/js/idx-recaptcha.min.js', [], '1.0.0', false );
-		wp_register_script( 'google-recaptcha', 'https://www.google.com/recaptcha/api.js?render=6LcUhOYUAAAAAF694SR5_qDv-ZdRHv77I6ZmSiij', [], '1.0.0', false );
+		wp_register_script( 'idx-google-recaptcha', 'https://www.google.com/recaptcha/api.js?render=6LcUhOYUAAAAAF694SR5_qDv-ZdRHv77I6ZmSiij', [], '1.0.0', false );
 		wp_register_script( 'owl2', IMPRESS_IDX_URL . 'assets/js/owl2.carousel.min.js', [ 'jquery' ], '1.0.0', false );
 	}
 

--- a/idx/shortcodes/impress-lead-signup-shortcode.php
+++ b/idx/shortcodes/impress-lead-signup-shortcode.php
@@ -57,7 +57,7 @@ class Impress_Lead_Signup_Shortcode {
 
 		if ( ! empty( get_option( 'idx_recaptcha_enabled' ) ) || ! empty( get_option( 'idx_recaptcha_site_key' ) ) ) {
 			wp_enqueue_script( 'idx-recaptcha' );
-			wp_enqueue_script( 'google-recaptcha' );
+			wp_enqueue_script( 'idx-google-recaptcha' );
 			wp_enqueue_script( 'jquery' );
 		}
 

--- a/idx/widgets/impress-lead-signup-widget.php
+++ b/idx/widgets/impress-lead-signup-widget.php
@@ -103,7 +103,7 @@ class Impress_Lead_Signup_Widget extends \WP_Widget {
 
 		if ( ! empty( get_option( 'idx_recaptcha_enabled' ) ) || ! empty( get_option( 'idx_recaptcha_site_key' ) ) ) {
 			wp_enqueue_script( 'idx-recaptcha' );
-			wp_enqueue_script( 'google-recaptcha' );
+			wp_enqueue_script( 'idx-google-recaptcha' );
 			wp_enqueue_script( 'jquery' );
 		}
 


### PR DESCRIPTION
… to avoid a conflict with Contact Form 7

Contact Form 7 uses wp_enqueue_script( 'google-recaptcha' ); when embedding reCAPTCHA with its forms---since our plugin was using the same name to enqueue our own recaptcha script, having IMPress activated alongside CF7 resulted in CF7 being unable to receive a recaptcha response, resulting in CF7 submissions being rejected as spam.

To verify this is an issue:

1. Download and activate Contact Form 7 on a test WordPress site.
2. Embed any CF7 form (like the default one provided when first installed) on a page.
3. Setup reCAPTCHA in the CF7 integration settings.
4. Make a test submission for CF7 to verify that it is working.
5. Download and activate IMPress for IDX Broker v3.0.9.
6. Make another test submission for CF7. This submission should fail.

Attached zip file contains the changes in this PR which resolve the conflict with CF7.

[idx-broker-platinum-recaptcha-fix.zip](https://github.com/idxbroker/wordpress-plugin/files/8138823/idx-broker-platinum-recaptcha-fix.zip)
.