### PR TITLE
IMPB-1461  Omnibar gives a "Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase')" when trying to search

### DIFF
--- a/src/vue/backend/src/templates/omnibarForm.vue
+++ b/src/vue/backend/src/templates/omnibarForm.vue
@@ -299,6 +299,14 @@ export default {
             // Adds a label with the user friendly name
             // Save original label used on the backend
             const cleanLabel = item.label
+            // When an MLS becomes unapproved on an account that previously set custom fields, MLSName can sometimes be undefined... we handle it here:
+            if (!MLSName) {
+                return {
+                    ...item,
+                    label: `${item.label} - missing MLS ${item.idxID}`,
+                    cleanLabel
+                }
+            }
             // Finds the property type the item is in
             const propType = MLSName.propertyTypes.find(x => {
                 return x.value === item.mlsPtID


### PR DESCRIPTION
add check for MLSName existence to the addCleanLabel() function in omnibarForm.vue to prevent the settings page from breaking.

Some users have observed that the Omnibar settings page within the IMPress plugin breaks under certain circumstances---it seems to be related to custom fields that are set for an at the time active MLS feed on the IDX Broker account. When the MLS feed becomes deactivated or removed from the account, the call to wp-json/idbroker/v1/admin/settings/omnibar (used on the Omnibar settings page) does not include data for the removed or deactivated MLS which in turn causes findMLSName() in omnibarForm.vue to return null when it tries to look up information for each custom field that was added while the now-removed MLS was still active on the account.

...yeah, it's kind of complicated---it's probably easier to understand by replicating the issue:

1. Add an MLS like a686 to your test IDX Broker account and approve it.
2. Refresh plugin options within IMPress and use the Omnibar settings page to add some custom fields specific to a686 (like Acres)
3. Deactivate a686 on your test IDX Broker account.
4. Refresh plugin options again, do a hard refresh on the Omnibar settings page. Your settings page should stop working with an error like the following in the browser console:  

```
TypeError: Cannot read properties of undefined (reading 'label')
    at addCleanLabel (omnibarForm.vue:309:1)
    at omnibarForm.vue:271:1
    at Array.forEach (<anonymous>)
    at a (omnibarForm.vue:266:1)
    at a.customFieldsOptionsCleaned (omnibarForm.vue:260:9)
    at nr.get (vue.runtime.esm.js:4479:25)
    at nr.evaluate (vue.runtime.esm.js:4584:21)
    at a.customFieldsOptionsCleaned (vue.runtime.esm.js:4836:17)
    at a.r (omnibarForm.vue?5c02:6:5164)
    at a.t._render (vue.runtime.esm.js:3548:22)
```

The fix applied here checks for a missing MLSName object when addCleanLabel is executed. Instead of breaking the settings page, the user will instead see something like this, allowing them to remove the erroneous custom fields if they choose:

![image](https://user-images.githubusercontent.com/33957656/157177428-85f19694-fa56-4a9f-975d-c3113d531fb6.png)

Not sure if we're supposed to include the re-built vue files... but attached is the fix and re-built template applied to 3.0.9.
[idx-broker-platinum-3.0.9-omnibar-settings-fix.zip](https://github.com/idxbroker/wordpress-plugin/files/8203173/idx-broker-platinum-3.0.9-omnibar-settings-fix.zip)
