### PR TITLE
IMPB-1458  Impress wrapper tool does not respect the selected page in the "Apply wrapper to IDX pages" dropdown

### DIFF
--- a/idx/wrappers.php
+++ b/idx/wrappers.php
@@ -363,18 +363,17 @@ class Wrappers {
 
 		// Validate and process request.
 		if ( isset( $_POST['idx-wrapper-page-nonce'], $_POST['idx-wrapper-page'] ) || wp_verify_nonce( sanitize_key( $_POST['idx-wrapper-page-nonce'] ), 'idx-wrapper-page' ) ) {
+			// meta_value is the IDX Broker page ID (or 'none' or 'global') that should have its wrapper updated
 			$meta_value = sanitize_text_field( wp_unslash( $_POST['idx-wrapper-page'] ) );
-			// Find the IDX Page ID by matching URLs.
-			$idx_page_id = $this->find_idx_url( $post_id );
-			// do not update wrapper if wrapper is none.
+			// If 'none' was selected on the post, don't update anything
 			if ( 'none' === $meta_value ) {
 				return;
 			} elseif ( 'global' === $meta_value ) {
 				$this->idx_api->set_wrapper( $idx_page_id, '' );
 			}
+			// Get the edited wrapper's URL to set the wrapper with
 			$wrapper_page_url = get_permalink();
-			// logic for what type of idx page is in Idx_Api class.
-			$this->idx_api->set_wrapper( $idx_page_id, $wrapper_page_url );
+			$this->idx_api->set_wrapper( $meta_value, $wrapper_page_url );
 			update_post_meta( $post_id, 'idx-wrapper-page', $meta_value );
 		}
 	}


### PR DESCRIPTION
use $meta_value instead of find_idx_url and $idx_page_id when setting the dynamic wrapper for an IDX Broker page from the "edit wrapper" WordPress page

$meta_value is provided by the wrapper page being edited within WordPress and is already set to the internal page ID or saved link ID that needs to be used when sending an update to /dynamicwrapperurl, so using it instead of trying to lookup the ID via the WordPress wrapper post ID resolves the behavior where trying to set a wrapper for a specific IDX Broker page from the Edit Wrapper page was instead always setting the global wrapper

The followings screenshot shows the "Apply Wrapper to IDX Pages" metabox where the user would choose what page they want to apply the wrapper to:

![image](https://user-images.githubusercontent.com/33957656/158335624-0805d7be-5237-484b-a45f-3015b096cf46.png)

--------

Verified corrected behavior by creating and editing a new wrapper page within a test WordPress account linked to a test IDX Broker account. With the fix in place, choosing a specific saved link or IDX Broker page to apply the wrapper to when editing the wrapper will only apply the change to the chosen page within the IDX Broker account, as expected.

Attached zip file is the 3.0.9 version of the plugin with these changes applied to it:
[idx-broker-platinum-3.0.9-apply-wrapper-fix.zip](https://github.com/idxbroker/wordpress-plugin/files/8251378/idx-broker-platinum-3.0.9-apply-wrapper-fix.zip)
