### PR TITLE
IMPB-1448 IMPress plugin chunk loading errors when WP is installed on subfolder domain

### DIFF
--- a/src/vue/backend/vue.config.js
+++ b/src/vue/backend/vue.config.js
@@ -15,7 +15,7 @@ module.exports = {
         headers: { 'Access-Control-Allow-Origin': '*' }
     },
     outputDir:  process.env.NODE_ENV === 'production' ? path.resolve(__dirname, '../../../assets/vue/backend') : path.resolve(__dirname, '../../../assets/vue-dev/backend'),
-    publicPath: process.env.NODE_ENV === 'production' ? '/wp-content/plugins/idx-broker-platinum/assets/vue/backend' : `http://localhost:${devPort}/`,
+    publicPath: process.env.NODE_ENV === 'production' ? '../wp-content/plugins/idx-broker-platinum/assets/vue/backend' : `http://localhost:${devPort}/`,
     configureWebpack: {
         output: {
             filename: 'admin.js',


### PR DESCRIPTION
the backend of the IMPress plugin is built with Vue. these components are packaged with webpack and loaded through the publicPath url when going to the settings page for IMPress. before this PR the publicPath url is set to the following:

`'/wp-content/plugins/idx-broker-platinum/assets/vue/backend'`

when a WordPress site is installed at the root level, there isn't any issue with this. `https://example.com/wp-admin/` will load the backend chunks from `https;//example.com/wp-content/plugins/idx-broker-platinum/assets/vue/backend`.

however, if a WordPress site is installed at a subdirectory like `https://example.com/site1/`, the wp-content files will be located at `https://example.com/site1/wp-content/...`. but the above pathing for publicPath means the chunks are still attempted to be loaded through `https://example.com/wp-content/...`. this results in 404 errors and the backend settings page not working for IMPress.

making publicPath relative allows for the packed components to work with subdirectory WordPress installations. With publicPath set to `../wp-content/plugins/idx-broker-platinum/assets/vue/backend` both a root installation and subdirectory installation loads the chunks from one directory above /wp-admin/ which is where the chunk files reside:

`https://example.com/wp-admin/../wp-content/plugins/idx-broker-platinum/assets/vue/backend` will load from `https://example.com/wp-content/plugins/idx-broker-platinum/assets/vue/backend`.

`https://example.com/site1/wp-admin/../wp-content/plugins/idx-broker-platinum/assets/vue/backend` will load from `https://example.com/site1/wp-content/plugins/idx-broker-platinum/assets/vue/backend`.

this should be extensively tested before merging as it's possible making the publicPath relative breaks the plugin in other places that aren't immediately apparent 

attached is a zip file with the Vue files rebuilt with a relative path for 3.0.9.
[idx-broker-platinum-3.0.9-relative-webpack.zip](https://github.com/idxbroker/wordpress-plugin/files/8368052/idx-broker-platinum-3.0.9-relative-webpack.zip)

screenshot of chunk errors with current 3.0.9:

![image](https://user-images.githubusercontent.com/33957656/160533632-14011809-97cb-48c3-94b8-51777bad5b05.png)

screenshot of settings page loading properly with 3.0.9 rebuilt with the relative path: 
![image](https://user-images.githubusercontent.com/33957656/160533903-ba327905-27e2-441e-ada1-0923cb98216f.png)
