### PR TITLE
ER-1901 Accessibility for Omnibar search

### DIFF
--- a/idx/widgets/omnibar/create-omnibar.php
+++ b/idx/widgets/omnibar/create-omnibar.php
@@ -74,7 +74,7 @@ class Create_Omnibar {
         <form class="idx-omnibar-form idx-omnibar-original-form">
           <label for="omnibar" class="screen-reader-text">$placeholder</label>
           <input id="omnibar" class="idx-omnibar-input" type="text" placeholder="$placeholder"><button type="submit" value="Search" aria-label="Submit Search"><i class="fas fa-search"></i><span>Search</span></button>
-          <div class="idx-omnibar-extra idx-omnibar-price-container" style="display: none;"><label>Price Max</label><input class="idx-omnibar-price" type="number" min="0" step="10000"></div><div class="idx-omnibar-extra idx-omnibar-bed-container" style="display: none;"><label>Beds</label><input class="idx-omnibar-bed" type="number" min="0" step="1"></div><div class="idx-omnibar-extra idx-omnibar-bath-container" style="display: none;"><label>Baths</label><input class="idx-omnibar-bath" type="number" min="0" step="1"></div>
+          <div class="idx-omnibar-extra idx-omnibar-price-container" style="display: none;"><label>Price Max<input class="idx-omnibar-price" type="number" min="0" step="10000"></label></div><div class="idx-omnibar-extra idx-omnibar-bed-container" style="display: none;"><label>Beds<input class="idx-omnibar-bed" type="number" min="0" step="1"></label></div><div class="idx-omnibar-extra idx-omnibar-bath-container" style="display: none;"><label>Baths<input class="idx-omnibar-bath" type="number" min="0" step="1"></label></div>
         </form>
 EOD;
 	}
@@ -133,7 +133,7 @@ EOD;
     <form class="idx-omnibar-form idx-omnibar-extra-form">
       <label for="omnibar" class="screen-reader-text">$placeholder</label>
       <input id="omnibar" class="idx-omnibar-input idx-omnibar-extra-input" type="text" placeholder="$placeholder">
-      $price_field<div class="idx-omnibar-extra idx-omnibar-bed-container"><label>Beds</label><input class="idx-omnibar-bed" type="number" min="0" step="1"></div><div class="idx-omnibar-extra idx-omnibar-bath-container"><label>Baths</label><input class="idx-omnibar-bath" type="number" min="0" step="1" title="Only numbers and decimals are allowed"></div>
+      $price_field<div class="idx-omnibar-extra idx-omnibar-bed-container"><label>Beds<input class="idx-omnibar-bed" type="number" min="0" step="1"></label></div><div class="idx-omnibar-extra idx-omnibar-bath-container"><label>Baths<input class="idx-omnibar-bath" type="number" min="0" step="1" title="Only numbers and decimals are allowed"></label></div>
       <button class="idx-omnibar-extra-button" type="submit" value="Search" aria-label="Submit Search"><i class="fas fa-search"></i><span>Search</span></button>
     </form>
 EOD;
@@ -148,9 +148,9 @@ EOD;
 	 */
 	public function price_field( $min_price ) {
 		if ( empty( $min_price ) ) {
-			$price_field = '<div class="idx-omnibar-extra idx-omnibar-price-container"><label>Price Max</label><input class="idx-omnibar-price" type="number" min="0" step="10000"></div>';
+			$price_field = '<div class="idx-omnibar-extra idx-omnibar-price-container"><label>Price Max<input class="idx-omnibar-price" type="number" min="0" step="10000"></label></div>';
 		} else {
-			$price_field = '<div class="idx-omnibar-extra idx-omnibar-price-container idx-omnibar-min-price-container"><label>Price Min</label><input class="idx-omnibar-min-price" type="number" min="0" step="10000"></div><div class="idx-omnibar-extra idx-omnibar-price-container idx-omnibar-max-price-container"><label>Price Max</label><input class="idx-omnibar-price" type="number" min="0" step="10000"></div>';
+			$price_field = '<div class="idx-omnibar-extra idx-omnibar-price-container idx-omnibar-min-price-container"><label>Price Min<input class="idx-omnibar-min-price" type="number" min="0" step="10000"></label></div><div class="idx-omnibar-extra idx-omnibar-price-container idx-omnibar-max-price-container"><label>Price Max<input class="idx-omnibar-price" type="number" min="0" step="10000"></label></div>';
 		}
 
 		return $price_field;


### PR DESCRIPTION
this implements ER-1901, accessibility enhancement request for the omnibar.

currently the Omnibar widget does not wrap the input elements it provides with a label which is an accessibility concern---this PR adjusts the HTML structure of the Omnibar to correct this. 

this will potentially affect any custom CSS that previously relied on the label element being closed before the input element.

**to replicate the issue**: 
1. with 3.0.9 installed on a test site, add the Omnibar to any page on your site.
2. run the page with the Omnibar through the https://wave.webaim.org/ tool
3. note that there are errors with the inputs associated with the Omnibar

![image](https://user-images.githubusercontent.com/33957656/161686300-aae6861d-de3a-4e88-9b68-4da3790d78e5.png)

**to confirm the fix**:
1. install the updated plugin (provided by attached zip file or by rebuilding the plugin from source with the PR)
2. run the page with the Omnibar through the  https://wave.webaim.org/ tool
3. note that the errors detected by the WAVE tool have been resolved

![image](https://user-images.githubusercontent.com/33957656/161686472-3834d21d-0780-48a9-b2d1-c3e650ff6a23.png)

[idx-broker-platinum-3.0.9-omnibar-labels.zip](https://github.com/idxbroker/wordpress-plugin/files/8415173/idx-broker-platinum-3.0.9-omnibar-labels.zip)
