### PR TITLE
IMPB-1460 CF7 and IDX Broker plugin error on PHP8 on form submission

### DIFF
--- a/idx/leads/class-contact-form-7.php
+++ b/idx/leads/class-contact-form-7.php
@@ -50,7 +50,7 @@ class IDX_Leads_CF7 {
 		wp_enqueue_style( 'idx-tooltip-css', IMPRESS_IDX_URL . 'assets/css/tooltip.min.css', [], '1.0.0' );
 	}
 
-	public function idx_save_lead_settings( $args ) {
+	public static function idx_save_lead_settings( $args ) {
 
 		if ( ! empty( $_POST ) ) {
 
@@ -240,7 +240,7 @@ class IDX_Leads_CF7 {
 		<?php
 	}
 
-	public function idx_put_lead( $contact_form ) {
+	public static function idx_put_lead( $contact_form ) {
 		$form_id = $contact_form->id;
 
 		$option_name = 'idx_lead_form_' . $form_id;


### PR DESCRIPTION
in PHP8 it is a fatal error to call non-static methods in a static way.

this is something that CF7 does with the functions we provide in idx\leads\class-contact-form-7.php and most of the functions are static except for idx_save_lead_settings and idx_put_lead.
i don't see any issues with making these functions static as well and doing so makes our plugin compatible with cf7 in PHP8.

attached is a zip file with the changes applied to IMPress 3.0.9's class-contact-form-7.php file for testing. i've tested this on both PHP8.0 and PHP7.4 with a simple contact form linked through the IDX Broker API and leads are submitted successfully on both versions.

during testing, i had to resave the CF7 form when uploading new versions of the plugin to reconnect the form to the IDX Broker account---you may have to do this as well if you upload the below file to overwrite an already installed and activated version of IMPress.

[idx-broker-platinum-3.0.9-php8-cf7-lead-import-fix.zip](https://github.com/idxbroker/wordpress-plugin/files/8558176/idx-broker-platinum-3.0.9-php8-cf7-lead-import-fix.zip)