### PR TITLE
Imported agents data sync fix

### DIFF
--- a/add-ons/agents/includes/class-agent-import.php
+++ b/add-ons/agents/includes/class-agent-import.php
@@ -116,7 +116,7 @@ class IMPress_Agents_Import {
 			foreach ( $agent_posts->posts as $post ) {
 				$post_meta = get_post_meta( $post->ID );
 				if ( ! empty( $post_meta['_employee_agentid'][0] ) ) {
-					array_push( $imported_agents, [ $post_meta['_employee_agentid'][0] => $post->ID ] );
+					$imported_agents[$post_meta['_employee_agentid'][0]] = $post->ID;
 				}
 			}
 		}
@@ -147,51 +147,51 @@ class IMPress_Agents_Import {
 
 		// Add post meta for existing fields.
 		// Title.
-		if ( get_post_meta( $id, '_employee_title' ) == false ) {
+		if ( get_post_meta( $id, '_employee_title', true ) == false ) {
 			update_post_meta( $id, '_employee_title', $idx_agent_data['agentTitle'] );
 		}
 		// First Name.
-		if ( get_post_meta( $id, '_employee_first_name' ) == false ) {
+		if ( get_post_meta( $id, '_employee_first_name', true ) == false ) {
 			update_post_meta( $id, '_employee_first_name', $idx_agent_data['agentFirstName'] );
 		}
 		// Last Name.
-		if ( get_post_meta( $id, '_employee_last_name' ) == false ) {
+		if ( get_post_meta( $id, '_employee_last_name', true ) == false ) {
 			update_post_meta( $id, '_employee_last_name', $idx_agent_data['agentLastName'] );
 		}
 		// Agent ID.
-		if ( get_post_meta( $id, '_employee_agent_id' ) == false ) {
+		if ( get_post_meta( $id, '_employee_agent_id', true ) == false ) {
 			update_post_meta( $id, '_employee_agent_id', $idx_agent_data['agentID'] );
 		}
 		// Main Phone.
-		if ( get_post_meta( $id, '_employee_phone' ) == false ) {
+		if ( get_post_meta( $id, '_employee_phone', true ) == false ) {
 			update_post_meta( $id, '_employee_phone', $idx_agent_data['agentContactPhone'] );
 		}
 		// Cell Phone.
-		if ( get_post_meta( $id, '_employee_mobile' ) == false ) {
+		if ( get_post_meta( $id, '_employee_mobile', true ) == false ) {
 			update_post_meta( $id, '_employee_mobile', $idx_agent_data['agentCellPhone'] );
 		}
 		// Email.
-		if ( get_post_meta( $id, '_employee_email' ) == false ) {
+		if ( get_post_meta( $id, '_employee_email', true ) == false ) {
 			update_post_meta( $id, '_employee_email', $idx_agent_data['agentEmail'] );
 		}
 		// Website URL.
-		if ( get_post_meta( $id, '_employee_website' ) == false ) {
+		if ( get_post_meta( $id, '_employee_website', true ) == false ) {
 			update_post_meta( $id, '_employee_website', $idx_agent_data['agentURL'] );
 		}
 		// Street Address.
-		if ( get_post_meta( $id, '_employee_address' ) == false ) {
+		if ( get_post_meta( $id, '_employee_address', true ) == false ) {
 			update_post_meta( $id, '_employee_address', $idx_agent_data['address'] );
 		}
 		// City.
-		if ( get_post_meta( $id, '_employee_city' ) == false ) {
+		if ( get_post_meta( $id, '_employee_city', true ) == false ) {
 			update_post_meta( $id, '_employee_city', $idx_agent_data['city'] );
 		}
 		// State.
-		if ( get_post_meta( $id, '_employee_state' ) == false ) {
+		if ( get_post_meta( $id, '_employee_state', true ) == false ) {
 			update_post_meta( $id, '_employee_state', $idx_agent_data['stateProvince'] );
 		}
 		// Zip Code.
-		if ( get_post_meta( $id, '_employee_zip' ) == false ) {
+		if ( get_post_meta( $id, '_employee_zip', true ) == false ) {
 			update_post_meta( $id, '_employee_zip', $idx_agent_data['zipCode'] );
 		}
 


### PR DESCRIPTION
### Description of the Change

The "Agents/Employees" add-on runs a daily scheduled event that fires a function called "impress_agents_update_post", this function collects all the imported "Employees (Agents)" that are fetched from the IDXBroker API using the IMPress Agent import functionality and updates the posts meta if new data is returned from the IDXBroker API.

As is, the function does nothing due to two bugs:
1. The function that collects all the post ID's adds the agentID / post ID's pair in a numeric array, but then tries to match them with the API response data as if they were added in an associative array. To fix this I changed the way ID's are added to the array.
2. The ID's are then pushed to a function called "impress_agents_idx_insert_post_meta" that is supposed to update the the posts meta fields if they are empty, however that function incorrectly checks if the meta values are empty. get_post_meta by default returns an array (even if no meta value is present it will return an empty array) so it will never return empty value, to fix this I've added "true" as the third parameter of all instances of "get_post_meta" in that function, that way get_post_meta returns the field value.

### Verification Process
You can reproduce the bug by importing agents from IDXBroker, add new data in the agents profile and execute the scheduled event "impress_agents_idx_update", it will not do anything.

With this change meta field values are updated with the new user data added in the IDXBroker dashboard.

The only other function that is using the "impress_agents_idx_insert_post_meta" is the agent import process, I tried importing agents on a fresh install and there are no issues with this change.

### Release Notes

Fix: User data sync for imported agents.


## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
