### PR TITLE
Handling city, county and zipcode 400 errors causing the Omnibar to break when an MLS is no longer available on an account

### DIFF
--- a/idx/idx-api.php
+++ b/idx/idx-api.php
@@ -66,6 +66,7 @@ class Idx_Api {
 					$err_message = 'API call generated from WordPress is not using SSL (HTTPS) to communicate.<br />Please contact your developer and/or hosting provider.';
 					$rest_error  = 'API call generated from WordPress is not using SSL (HTTPS) to communicate.';
 					break;
+				case 400:
 				case 405:
 				case 409:
 					$err_message = 'Invalid request sent to IDX Broker API, please re-install the IMPress for IDX Broker plugin.';

--- a/idx/widgets/omnibar/get-locations.php
+++ b/idx/widgets/omnibar/get-locations.php
@@ -186,10 +186,29 @@ class Get_Locations {
 			$omnibar_zipcode = 'combinedActiveMLS';
 			update_option( 'idx_omnibar_current_zipcode_list', 'combinedActiveMLS', false );
 		}
+
 		// grab responses for CCZs and add JSON object container for front end JavaScript
-		$cities   = '"cities" : ' . json_encode( $this->idx_api->idx_api( "cities/$omnibar_city" ) );
-		$counties = ', "counties" : ' . json_encode( $this->idx_api->idx_api( "counties/$omnibar_county" ) );
-		$zipcodes = ', "zipcodes" : ' . json_encode( $this->idx_api->idx_api( "postalcodes/$omnibar_zipcode" ) );
+		// note that if an MLS explicitly set by the user undergoes a vendor migration or is removed from the account we might receive a 400 error reponse from the API when we try to get a list of the cities, counties or zip codes.
+		// if this happens, we will retry with the default combinedActiveMLS
+
+		$cities_api_response = $this->idx_api->idx_api( "cities/$omnibar_city" );
+		if (is_wp_error($cities_api_response)) {
+			$cities_api_response = $this->idx_api->idx_api( "cities/combinedActiveMLS" );
+		}
+		$cities   = '"cities" : ' . json_encode( $cities_api_response );
+
+		$counties_api_response = $this->idx_api->idx_api( "counties/$omnibar_county" );
+		if (is_wp_error($counties_api_response)) {
+			$counties_api_response = $this->idx_api->idx_api( "counties/combinedActiveMLS" );
+		}
+		$counties = ', "counties" : ' . json_encode( $counties_api_response );
+
+		$zipcodes_api_response = $this->idx_api->idx_api( "postalcodes/$omnibar_zipcode" );
+		if (is_wp_error($zipcodes_api_response)) {
+			$zipcodes_api_response = $this->idx_api->idx_api( "postalcodes/combinedActiveMLS" );
+		}
+		$zipcodes = ', "zipcodes" : ' . json_encode( $zipcodes_api_response );
+
 		return $cities . $counties . $zipcodes;
 	}
 


### PR DESCRIPTION
### Description of the Change

An uncommon issue that occurs with our clients is that if the Omnibar is set to retrieve a list of cities, counties, or zipcodes for an MLS that is then removed from the IDX Broker account, the next time the locationlist.js file is generated it will contain instances of "Required parameter missing or invalid." the 400 error code message returned by our API. This breaks the Omnibar search functionality on the frontend of the site until the old MLS IDs are removed from the WordPress site configuration or new MLS IDs are set for the cities, counties and zipcode location options for the Omnibar.

This change adds detection for 400 responses from our API and with that detection will retry any errored city, county or zipcode requests with the default 'combinedActiveMLS' list.

### Verification Process

- With a test account, add any MLS that you will later remove, like a001.
- With IMPress 3.0.10 installed, set the city, county and zip code Omnibar location options within the WordPress account to use the MLS.
- Refresh plugin options. Check to verify that the locationlist.js file has been generated properly.
- Remove the MLS from the IDX Broker account.
- Refresh plugin options again. Recheck the locationlist.js file to confirm that it looks something like this:

`var customFieldsKey = {}; idxOmnibar( [{"core" : {"cities" : ["Required parameter missing or invalid."], "counties" : ["Required parameter missing or invalid."], "zipcodes" : ["Required parameter missing or invalid."]} }]);`

(note the "Required parameter missing or invalid" API error messages)
- Upload an updated version of the plugin containing these fixes
- Refresh plugin options. Recheck the locationlist.js file to confirm that combinedActiveMLS is now being used to generate a valid locationlist.js file.

### Release Notes

Fix for the situation where the Omnibar search would sometimes stop functioning if an MLS was migrated or removed from an IDX Broker account 