### PR TITLE
IMPB-1468 Edit Saved Link URL is incorrect

### DIFF
--- a/idx/views/search-management.php
+++ b/idx/views/search-management.php
@@ -337,7 +337,7 @@ class Search_Management {
 			echo '<td class="mdl-data-table__cell--non-numeric">' . esc_html( $search->timesViewed ) . '</td>';
 			echo '<td class="mdl-data-table__cell--non-numeric">
 						<a href="' . esc_url( admin_url( 'admin-ajax.php?action=idx_search_delete&ssid=' . $search->id . '&nonce=' . $nonce ) ) . '" id="delete-search-' . esc_attr( $search->id ) . '" class="delete-search" data-ssid="' . esc_attr( $search->id ) . '" data-nonce="' . esc_attr( $nonce ) . '"><i class="material-icons md-18">delete</i><div class="mdl-tooltip" data-mdl-for="delete-search-' . esc_attr( $search->id ) . '">Delete Search</div></a>
-						<a href="https://middleware.idxbroker.com/mgmt/addeditsavedlink.php?id=' . esc_attr( $search->id ) . '" id="edit-mw-' . esc_attr( $search->id ) . '" target="_blank"><i class="material-icons md-18">exit_to_app</i><div class="mdl-tooltip" data-mdl-for="edit-mw-' . esc_attr( $search->id ) . '">Edit Search in Middleware</div></a>
+						<a href="https://middleware.idxbroker.com/mgmt/saved-links/' . esc_attr( $search->id ) . '/edit" id="edit-mw-' . esc_attr( $search->id ) . '" target="_blank"><i class="material-icons md-18">exit_to_app</i><div class="mdl-tooltip" data-mdl-for="edit-mw-' . esc_attr( $search->id ) . '">Edit Search in Middleware</div></a>
 						</td>';
 			echo '</tr>';
 		}

--- a/idx/views/search-management.php
+++ b/idx/views/search-management.php
@@ -46,7 +46,7 @@ class Search_Management {
 		$this->page = add_submenu_page(
 			'idx-broker',
 			'Searches',
-			'Saved Searches',
+			'Saved Links',
 			'manage_options',
 			'idx-searches',
 			array(


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Yes

📝 Are you updating documentation?

💻 Are you changing functionality?

### Description of the Change

1. Main sidebar menu refers to saved links as 'Saved Searches'. [151667b](https://github.com/idxbroker/wordpress-plugin/pull/446/commits/151667bddbd8183343007945692c64f6d1cf54a3) updates the menu item text to 'Saved Links'

2. Links to edit saved links in middleware are improperly formatted. [ef5b915](https://github.com/idxbroker/wordpress-plugin/pull/446/commits/ef5b915991cd2ab1643fad9e73671b11e212f98f) updates the generated link to take the user to the correct page.

### Verification Process

1. Verify sidebar menu name for IMPress > Saved Searches with and without the changes in place
2. Navigate to IMPress > Saved Searches, click on edit search in middleware icon with and without changes in place

### Release Notes

Fix: IMPress > Saved Searches links to modify saved links in the IDX Broker account work again.

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
