### PR TITLE
IMPB-1476  Unable to create leads via IMPress plugin add lead form

### DIFF
--- a/idx/views/lead-management.php
+++ b/idx/views/lead-management.php
@@ -154,7 +154,7 @@ class Lead_Management {
 					'outputtype'   => 'json',
 				),
 				'sslverify' => false,
-				'body'      => sanitize_text_field( wp_unslash( $_POST['fields'] ) ),
+				'body'      => sanitize_text_field( urldecode( $_POST['fields'] ) ),
 			);
 			$response = wp_remote_request( $api_url, $args );
 


### PR DESCRIPTION
# Pull Requests

Please explain the intent of your Pull Request.

🐛 Are you fixing a bug? Yes

## Template

### Description of the Change

idx_lead_add is used when a user tries to create a new lead through Leads > Add Lead within WordPress.

when the 'Add Lead' form is submitted, it's first serialized with $.serialize. this converts the form into a percent encoded form which is sent to the server.

the server receives the percent encoded form and uses sanitize_text_field to sanitize it. however, since emails contain an @ symbol like in test@example.com, the @ symbol in the address was converted into a percent encoded form. looking at the source code for WordPress's sanitize_text_field, it removes percent encoded characters from the string in addition to the rest of the checks it does. this results in the @ symbol being effectively stripped away from the email, which then results in the server returning a 500 error and not adding the lead properly.

changing wp_unslash to urldecode converts the percent encoded @ symbol back to an @ which passes through the sanitize_text_field safely and thus allowing the lead to be added to the account.

### Verification Process

without the fix, attempted to create a lead through WordPress. observe that the request sent to the server did not include an @ symbol for the email address.

with the change in place, again attempted to create a lead through WordPress. observed that the request sent to the server included the @ symbol this time and the lead was created within the IDX Broker account.

### Release Notes

Fix: Leads can again be created through Leads > Add Lead

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
