### PR TITLE
IMPB-1477 Clicking on Lead name within Leads > Leads produces a nonce error

### DIFF
--- a/idx/views/lead-management.php
+++ b/idx/views/lead-management.php
@@ -644,7 +644,7 @@ class Lead_Management {
 			// Column 6 = Actions (edit, delete, MW link).
 
 			$current_lead = [
-				0 => '<td class="mdl-data-table__cell--non-numeric"><a href="' . esc_url( admin_url( 'admin.php?page=edit-lead&leadID=' . $lead->id ) ) . '">' . get_avatar( $lead->email, 32, '', 'Lead photo', $avatar_args ) . ' ' . esc_html( $lead->firstName ) . ' ' . esc_html( $lead->lastName ) . '</a></td>',
+				0 => '<td class="mdl-data-table__cell--non-numeric"><a href="' . esc_url( admin_url( 'admin.php?page=edit-lead&leadID=' . $lead->id . '&nonce=' . $edit_lead_nonce ) ) . '">' . get_avatar( $lead->email, 32, '', 'Lead photo', $avatar_args ) . ' ' . esc_html( $lead->firstName ) . ' ' . esc_html( $lead->lastName ) . '</a></td>',
 				1 => '<td class="mdl-data-table__cell--non-numeric"><a id="mail-lead-' . esc_attr( $lead->id ) . '" href="mailto:' . $lead->email . '" target="_blank">' . $lead->email . '</a><div class="mdl-tooltip" data-mdl-for="mail-lead-' . $lead->id . '">Email Lead</div></td>',
 				2 => '<td class="mdl-data-table__cell--non-numeric">' . esc_html( $lead->phone ) . '</td>',
 				3 => '<td class="mdl-data-table__cell--non-numeric">' . esc_html( $subscribed_on ) . '</td>',


### PR DESCRIPTION
# Pull Requests

👋 Hello there! Welcome. Please follow the steps below to tell us about your contribution.

Lead names are linked within Leads > Leads for leads within IMPress/IDX Broker. The links on the left are missing the nonce, so when the name is clicked on the left instead of being able to edit the lead a nonce error appears.

This fix adds the nonce back to the lead link.

🐛 Are you fixing a bug? Yes

📝 Are you updating documentation?

💻 Are you changing functionality?

Remember to state clearly and in detail, leaving no room for confusion about the intent of your Pull Request

## Template

### Description of the Change

Add nonce to the edit leads name link within Leads > Leads when using WordPress.

### Verification Process

Click on the lead's name with and without the change in place when looking at Leads > Leads

### Release Notes

N/A

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
