### PR TITLE
IMPB-1469 Editing saved property removes name value

### DIFF
--- a/idx/views/lead-management.php
+++ b/idx/views/lead-management.php
@@ -362,7 +362,7 @@ class Lead_Management {
 			$spid    = sanitize_text_field( wp_unslash( $_POST['spid'] ) );
 
 			$property_array = array(
-				'propertyName'   => sanitize_text_field( wp_unslash( $_POST['property_name'] ) ),
+				'propertyName'   => sanitize_text_field( wp_unslash( $_POST['name'] ) ),
 				'receiveUpdates' => sanitize_text_field( wp_unslash( $_POST['updates'] ) ),
 				'property'       => array(
 					'idxID'     => sanitize_text_field( wp_unslash( $_POST['idxid'] ) ),


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Yes

📝 Are you updating documentation?

💻 Are you changing functionality?

### Description of the Change

When editing a saved property for a lead through IMPress, 'name' is the name of the field used to send the name of the property to the API. This is different from the expected 'property_name' within the plugin code, causing the name to be erased when the saved property is edited.

This change adjusts the name referred to in the plugin backend for this field from 'property_name' to 'name' so that the name for a saved listing can be properly updated.

### Verification Process

Edit and save the name for a saved property for a lead within IMPress with and without the changes in place.

### Release Notes

Fix: The name for a lead's saved property can again be updated through IMPress.

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
