### PR TITLE
IMPB-1470  Edit Leads saved property URL is incorrect

### DIFF
--- a/idx/views/lead-management.php
+++ b/idx/views/lead-management.php
@@ -1133,7 +1133,7 @@ class Lead_Management {
 
 										<a href="#" id="delete-property-' . esc_attr( $property['id'] ) . '" class="delete-property" data-id="' . esc_attr( $lead_id ) . '" data-spid="' . esc_attr( $property['id'] ) . '" data-nonce="' . esc_attr( wp_create_nonce( 'idx_lead_property_delete_nonce' ) ) . '"><i class="material-icons md-18">delete</i><div class="mdl-tooltip" data-mdl-for="delete-property-' . esc_attr( $property['id'] ) . '">Delete Saved Property</div></a>
 
-										<a href="https://middleware.idxbroker.com/mgmt/addeditsavedprop.php?id=' . esc_attr( $lead_id ) . '&spid=' . esc_attr( $property['id'] ) . '" id="edit-mw-' . esc_attr( $property['id'] ) . '" target="_blank"><i class="material-icons md-18">exit_to_app</i><div class="mdl-tooltip" data-mdl-for="edit-mw-' . esc_attr( $property['id'] ) . '">Edit Property in Middleware</div></a>
+										<a href="https://middleware.idxbroker.com/mgmt/leads/' . esc_attr( $lead_id ) . '/properties/' . esc_attr( $property['id'] ) . '/edit" id="edit-mw-' . esc_attr( $property['id'] ) . '" target="_blank"><i class="material-icons md-18">exit_to_app</i><div class="mdl-tooltip" data-mdl-for="edit-mw-' . esc_attr( $property['id'] ) . '">Edit Property in Middleware</div></a>
 										</td>';
 							echo '</tr>';
 						}


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Yes

📝 Are you updating documentation?

💻 Are you changing functionality?

### Description of the Change

URLs in IMPress to edit a lead's saved property in MW are improperly formatted and direct the user to create a new property instead when clicked.

This PR reformats the generated URL so that the expected listing is brought up for editing when the 'Edit Property in Middleware' icon link is clicked.

### Verification Process

Click on a 'Edit Property in Middleware' icon link for a saved listing for a lead with and without the changes in place.

### Release Notes

Fix: 'Edit Property in Middleware' icon links for a lead's saved listings now take the user to the correct Middleware page.

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
