### PR TITLE
IMPB-1471 Unable to delete lead saved search from IMPress dashboard UI

### DIFF
--- a/idx/views/lead-management.php
+++ b/idx/views/lead-management.php
@@ -525,9 +525,9 @@ class Lead_Management {
 			echo 'error';
 		} else {
 			$post_id = sanitize_text_field( wp_unslash( $_POST['id'] ) );
-			$spid    = sanitize_text_field( wp_unslash( $_POST['spid'] ) );
+			$ssid    = sanitize_text_field( wp_unslash( $_POST['ssid'] ) );
 			// Delete lead saved search via API.
-			$api_url  = IDX_API_URL . '/leads/search/' . $post_id . '/' . $spid;
+			$api_url  = IDX_API_URL . '/leads/search/' . $post_id . '/' . $ssid;
 			$args     = array(
 				'method'    => 'DELETE',
 				'headers'   => array(


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Yes

📝 Are you updating documentation?

💻 Are you changing functionality?

### Description of the Change

Attempting to delete a lead's saved search through the trashcan icon in IMPress does nothing. This is because the field name for the saved link ID is sent as 'ssid' but the backend is expecting 'spid'.

This PR changes spid to ssid in variable name and $_POST variable to match the id submitted by Edit Lead UI.

### Verification Process

Attempt to delete a saved search for any lead from within IMPress with and without the changes in place.

### Release Notes

Fix: A lead's saved searches can again be deleted through IMPress by clicking on the trash icon.

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.