### PR TITLE
IMPB-1479  CF7 and IDX Broker PHP warnings in WP Dashboard on PHP 8.0

### DIFF
--- a/idx/leads/class-contact-form-7.php
+++ b/idx/leads/class-contact-form-7.php
@@ -86,8 +86,7 @@ class IDX_Leads_CF7 {
 
 		$checked = false;
 		// $form_options could be false if this is a new form (since get_option returns false when it can't find anything)
-		if ($form_options!= false
-		&& array_key_exists('enable_lead', $form_options)) {
+		if ($form_options != false && array_key_exists('enable_lead', $form_options)) {
 			$checked = $form_options['enable_lead'];
 		}
 


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Yes

## Template

### Description of the Change

PHP8 doesn't like it if you try to use a non-existent key on an array (when checking for selected tags) or if you try to access a boolean as an array (get_option can return false)

rewrote code to avoid warnings

### Verification Process

Review PHP error log (or enable the display of warnings) when using the IDXB-CF7 tab to create and edit new forms and link them to IDXB.

### Release Notes

fix: resolve PHP8 errors when generating UI for IDXB tab in CF7

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
