### PR TITLE
IMPB-1434 Unable to Delete Leads from IMPress plugin

### DIFF
--- a/assets/js/idx-leads.js
+++ b/assets/js/idx-leads.js
@@ -24,6 +24,9 @@ jQuery(document).ready(function($) {
 				"orderable": false
 			}
 		],
+		"createdRow": function (row, data, index) {
+			$(row).addClass('lead-row');
+		},
 		"dom": '<"table-filter"f>rt<"lead-table-controls mdl-shadow--2dp"lip>',
 		"oLanguage": {
 			"sSearch": ""

--- a/idx/idx-api.php
+++ b/idx/idx-api.php
@@ -247,28 +247,44 @@ class Idx_Api {
 	}
 
 	/**
-	 * Clean IDX cached data
-	 *
-	 * @param void
+	 * Clean IDX cached data for all idx_ options containing $name, or all of these options in general, the wrapper cache and idx pages if nothing is provided
+	 * 
+	 * @param String $name, what name should be matched when clearing cached options. Defaults to an empty string.
 	 * @return void
 	 */
-	public function idx_clean_transients() {
+	public function idx_clean_transients($name = '') {
 		global $wpdb;
-		$wpdb->query(
-			$wpdb->prepare(
-				"
-                DELETE FROM $wpdb->options
-         WHERE option_name LIKE %s
-        ",
-				'%idx_%_cache'
-			)
-		);
 
-		$this->clear_wrapper_cache();
-
-		// Update IDX Pages Immediately.
-		wp_schedule_single_event( time(), 'idx_create_idx_pages' );
-		wp_schedule_single_event( time(), 'idx_delete_idx_pages' );
+		// If nothing was provided for the name of options to clear, clear everything.
+		if ($name === '') {
+			$wpdb->query(
+				$wpdb->prepare(
+					"
+					DELETE FROM $wpdb->options
+			 WHERE option_name LIKE %s
+			",
+					'%idx_%_cache'
+				)
+			);
+	
+			$this->clear_wrapper_cache();
+	
+			// Update IDX Pages Immediately.
+			wp_schedule_single_event( time(), 'idx_create_idx_pages' );
+			wp_schedule_single_event( time(), 'idx_delete_idx_pages' );
+		} else {
+			// If $name was set, only clear idx_*_cache options that contain that name		
+			$wpdb->query(
+				$wpdb->prepare(
+					"
+					DELETE FROM $wpdb->options
+			 WHERE option_name LIKE %s
+			",
+					'%idx_' . $name . '%_cache'
+				)
+			);
+	
+		}
 	}
 
 	/**

--- a/idx/views/lead-management.php
+++ b/idx/views/lead-management.php
@@ -164,7 +164,7 @@ class Lead_Management {
 				echo 'Lead already exists.';
 			} elseif ( wp_remote_retrieve_response_code( $response ) == '200' ) {
 				// Delete lead cache so new lead will show in list views immediately.
-				delete_option( 'idx_leads_lead_cache' );
+				$this->idx_api->idx_clean_transients('leads_lead');
 				// return new lead ID to script.
 				echo esc_html( $decoded_response['newID'] );
 			} else {
@@ -425,8 +425,7 @@ class Lead_Management {
 			$response = wp_remote_request( $api_url, $args );
 
 			if ( wp_remote_retrieve_response_code( $response ) == '204' ) {
-				delete_option( 'idx_leads_lead_cache' );
-				delete_option( 'idx_leads_lead/' . $post_id . '_cache' );
+				$this->idx_api->idx_clean_transients('leads_lead');
 				echo 'success';
 			} else {
 				echo 'error';


### PR DESCRIPTION
# Pull Requests

Please explain the intent of your Pull Request.

🐛 Are you fixing a bug? Yes

## Template

### Description of the Change

Leads are able to successfully be deleted within Leads > Leads when using IMPress but the data does not refresh due to how lead related data is cached inside an option---the plugin tries to clear the idx_leads_lead_cache option, which isn't ever actually set due to the offset being added to the name of cached lead data.

To ensure the list of leads are immediately updated as expected, the following changes were made:

1. Added optional $name parameter to idx_clean_transients so that specific types of cached data can be deleted by themselves
2. Updated lead-management.php lead-deletion-functions to make use of the new idx_clean_transients functionality and added 'lead-row' class to lead rows generated on Leads > Leads so they can be hidden after a successful deletion.

### Verification Process

Attempt to delete a lead within the Leads > Leads page within WordPress with and without the changes in place.

### Release Notes

fix: properly refresh list of leads within IMPress's Leads > Leads menu when deleting a lead

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
