### PR TITLE
IMPB-1247 IMPress Showcase widget does not apply column settings when using page builder widget

### DIFF
--- a/idx/widgets/impress-showcase-widget.php
+++ b/idx/widgets/impress-showcase-widget.php
@@ -18,7 +18,8 @@ class Impress_Showcase_Widget extends \WP_Widget {
 			'IMPress Property Showcase', // Name.
 			array(
 				'description'                 => 'Displays a showcase of properties',
-				'classname'                   => 'impress-showcase-widget',
+				// The class name used by the rest of the plugin to refer to styling the showcase widget is impress-property-showcase, but it was initially set to impress-showcase-widget. impress-showcase-widget has been left here for now to avoid possibly breaking functionality on client sites that may have been styling this widget using this class name.
+				'classname'                   => 'impress-showcase-widget impress-property-showcase',
 				'customize_selective_refresh' => true,
 			)
 		);


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Yes

## Template

### Description of the Change

Impress-property-showcase is the classname used by our CSS to style the widget and arrange the listings according to the "listings per row" option---this classname property is also used by page builders like beaver builder when inserting our widgets into the page.

This PR adds impress-property-showcase to classname set for the showcase widget.

Prior to this change the classname set on the showcase widget was impress-showcase-widget, which was not targeted by our CSS and causing the columns to not be formatted as expected when using a page builder to insert the widget.

Impress-showcase-widget has been left in the classname to avoid breaking any CSS created by clients or developer partners that might be using it to style our widget.

### Verification Process

Add a Showcase widget to a page using a page builder like beaver builder with and without the change in place.

### Release Notes

Fix: Showcase widget correctly takes into account the 'listings per row' option when used through a page builder plugin.

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
