### PR TITLE
IMPB-1491: Sort timestamps correctly in DataTables (used in Leads > Leads)

### DIFF
--- a/assets/js/idx-leads.js
+++ b/assets/js/idx-leads.js
@@ -1,6 +1,24 @@
 jQuery(document).ready(function($) {
 
 	// Initialize datatables
+
+	// Simple timestamp regex checker to determine if something is a timestamp 
+	let timestampRegex = /">(\w+, \w+ \d+, \d+ \d+:\d+ [A|P]M)<\/td>/
+
+	// Add ordering detection and functions for timestamps provided by PHP
+	$.fn.dataTable.ext.type.detect.unshift((d) => {
+		let timestampMatch = d?.match(timestampRegex);
+		if (timestampMatch
+		&& !isNaN(new Date(timestampMatch[1]))) {
+			return 'timestamp';
+		}
+		return null;
+	});
+
+	$.fn.dataTable.ext.type.order[ 'timestamp-pre' ] = function ( d ) {
+		let timestampMatch = d?.match(timestampRegex);
+		return (new Date(timestampMatch[1])).getTime();
+	};
 	
 	$('.mdl-data-table.leads').DataTable( {
 		"ajax": {


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Yes

## Template

### Description of the Change

This PR adds PHP timestamp detection and ordering to DataTables which is used to display leads and lead related data within Leads > Leads. 

Prior to this change, DataTables was not detecting the timestamp provided by the PHP side of IMPress and was thus sorting timestamp columns lexicographically.

With this change in place, timestamp columns are properly detected and sorted by date and time as expected.

### Verification Process

Sort the Leads > Leads table by any date columns (like Subscribed or Last Active) with and without the change in place.

### Release Notes

Fix: properly sort timestamp columns for lead related tables in Leads > Leads

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
