### PR TITLE
IMPB-1494  Similar IMPress carousel widget shows duplicate listing when there are not enough listings.

### DIFF
--- a/idx/shortcodes/register-impress-shortcodes.php
+++ b/idx/shortcodes/register-impress-shortcodes.php
@@ -581,7 +581,10 @@ class Register_Impress_Shortcodes {
 
 		$count = 0;
 
-		$output .= sprintf( '<div class="impress-carousel impress-listing-carousel-%s impress-carousel-shortcode owl-carousel owl-theme">', $display );
+		// The id set on the container and used by the output script to insert the listings into the page for this particular carousel
+		$carousel_id = uniqid('impress-carousel-');
+
+		$output .= sprintf( '<div id="%s" class="impress-carousel impress-listing-carousel-%s impress-carousel-shortcode owl-carousel owl-theme">', $carousel_id, $display);
 
 		// Used to hold agent data when matching for colistings.
 		$agent_data;
@@ -686,7 +689,7 @@ class Register_Impress_Shortcodes {
 		$output = '
         	<script>
 				window.addEventListener("DOMContentLoaded", function(event) {
-					jQuery(".impress-listing-carousel-' . $display . '").owlCarousel({
+					jQuery("#' . $carousel_id . '").owlCarousel({
 						items: ' . $display . ',
 						' . $autoplay_param . '
 						nav: true,

--- a/idx/widgets/impress-carousel-widget.php
+++ b/idx/widgets/impress-carousel-widget.php
@@ -127,7 +127,10 @@ class Impress_Carousel_Widget extends \WP_Widget {
 		$total = count( $properties );
 		$count = 0;
 
-		$output .= sprintf( '<div class="impress-carousel impress-listing-carousel-%s owl-carousel owl-theme">', $instance['display'] );
+		// The id set on the container and used by the output script to insert the listings into the page for this particular carousel
+		$carousel_id = uniqid('impress-carousel-');
+
+		$output .= sprintf( '<div id="%s" class="impress-carousel impress-listing-carousel-%s owl-carousel owl-theme">', $carousel_id, $instance['display'] );
 
 		// Used to hold agent data when matching for co-listings.
 		$agent_data;
@@ -230,7 +233,7 @@ class Impress_Carousel_Widget extends \WP_Widget {
 		$output = '
 			<script>
 				window.addEventListener("DOMContentLoaded", function(event) {
-					jQuery(".impress-listing-carousel-' . $display . '").owlCarousel({
+					jQuery("#' . $carousel_id . '").owlCarousel({
 						items: ' . $display . ',
 						' . $autoplay . '
 						nav: true,


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Yes

### Description of the Change

currently the plugin relies on the display attribute and a selection via class based on the display attribute to determine what element should be setup with owlCarousel. 

because the display attribute is not guaranteed to be unique, there are some situations where having multiple carousels on the same page can cause unexpected behavior and duplicated listings to be shown.

this PR changes the html output for the carousel widget and shortcode to instead use a unique id generated with uniqid() to avoid the unexpected behavior.

### Verification Process

1. setup an IDX Broker account so that you can pull in 1 featured listing via shortcode (like with an agentid set) and multiple supplemental listings via shortcode (by creating several supplemental listings).

2. create a page within a WordPress site with IMPress 3.0.10 that has two carousel widgets or shortcodes with the display attribute for each set to the same number (like 3), with the supplemental shortcode first followed by the featured shortcode (so that the widget with only a single listing appears after the widget with more listings)

3. publish the page and note that the second widget has its single listing duplicated. (see screenshot for example on live test site)

![image](https://user-images.githubusercontent.com/33957656/181696902-74767c08-5e36-463d-aeaa-f6f451a32f7b.png)

4. re-arrange the widgets so that they're in the opposite order. publish and note the different behavior (see screenshot, where the widgets are both set to display 3 but only a single listing is shown at a time for both)

![image](https://user-images.githubusercontent.com/33957656/181697141-42a55248-d155-48ec-b4c7-f697f3804078.png)

5. install version of plugin with fixes in PR applied. note that the behavior has been resolved and each widget is displaying listings as expected without duplication or limitation. (see screenshot)

![image](https://user-images.githubusercontent.com/33957656/181697486-6f44c083-6a6d-4a6c-bc2c-68c78e931653.png)

### Release Notes

Fix: corrected display of listings in carousel widgets when multiple carousel widgets on a single page shared the same display attribute

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
