### PR TITLE
IMPB-1495  Omnibar is reading in typed info as the Listing ID

### DIFF
--- a/src/js/idx-omnibar.js
+++ b/src/js/idx-omnibar.js
@@ -564,12 +564,19 @@ var idxOmnibar = function(jsonData){
 			goToResultsPage(input, idxUrl, '?idxID=' + AddressMLS + '&pt=' + mlsPtId + '&aw_address=' + input.value  + '&idxStatus=active&idxStatus=sold');
 			return;
 		}
+
+		// Listing ID Assumption:
+		// Either 1. is a single sequence of numbers without spaces
+		// 2. is a combination of letters and numbers without spaces, with at least one number
+		let hasNumbers = /\d/.test(input.value);
 		
-		var hasSpaces = /\s/g.test(input.value);
+		// \w: alphanumerics plus underscore, add hyphens - as well
+		let isSingleWord = /^[\w-]+$/.test(input.value);
+
 		if (!input.value) {
 			//nothing in input
 			goToResultsPage(input, idxUrl, '?pt=' + mlsPtId + '&srt=' + sortOrder);
-		} else if(hasSpaces === false && parseInt(input.value) !== isNaN) {
+		} else if (hasNumbers && isSingleWord) {
 			//MLS Number/ListingID
 			var listingID = true;
 			var agentHeaderID = false;


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Yes

### Description of the Change

When a client uses the Omnibar to search for a word without spaces, prior to this PR it is sometimes considered a ListingID even when it contains no numbers. For example, if you search "Morris" in an Omnibar under 3.0.10 you are directed to a listingID search for Morris which returns nothing when you may have expected it to do an address search with Morris instead.

Note that the previous check for whether something was a listingID effectively only took into account whether there were spaces

The new check for the Omnibar now only considers a string with the following characteristics to be a listing ID:

1. must have at least 1 digit somewhere
2. no spaces
3. is a combination of alphanumberics, _, and -

A string with all of the above characteristics is assumed to be a listing ID and a client searching for such a string will be directed to the listingID search results. Otherwise, the rest of the Omnibar checks are performed to see what type of search should be made. 

### Verification Process

With the fixes in the PR in place, try searching for 'Morris' in an Omnibar and note that you are now directed to an address search page. 

Additionally, try various combinations of letters, numbers and spaces to ensure that inputs that look like listing IDs are directed appropriately.

### Release Notes

Fix: More accurately determine when something is a Listing ID or not when searching with a single word with the Omnibar.

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
