### PR TITLE
IMPB-1497 idx pages sometimes never populate through create idx pages

### DIFF
--- a/idx/idx-pages.php
+++ b/idx/idx-pages.php
@@ -206,8 +206,19 @@ class Idx_Pages {
 	public function create_idx_pages() {
 		// Only schedule update once IDX pages have UID.
 		$uid_added = get_option( 'idx_added_uid_to_idx_pages' );
-		if ( empty( $uid_added ) ) {
+		
+		// see if there's data from <=v1.3 in the database by checking for the existence of a posts_idx table
+		$table_name =  $wpdb->prefix . 'posts_idx';
+		$old_idx_table_found = $wpdb->get_var("SHOW TABLES LIKE '$table_name'") == $table_name;
+
+		if ( empty( $uid_added ) && $old_idx_table_found ) {
 			return wp_schedule_single_event( time(), 'idx_add_uid_to_idx_pages' );
+		}
+
+		// if we didn't see any posts_idx table, assume there's nothing to migrate
+		if (!$old_idx_table_found) {
+			update_option( 'idx_migrated_old_table', true, false );
+			update_option( 'idx_add_uid_to_idx_pages', true, false );
 		}
 
 		$all_idx_pages = $this->get_all_api_idx_pages();


### PR DESCRIPTION
# Pull Requests

Please explain the intent of your Pull Request.

🐛 Are you fixing a bug? Yes

## Template

### Description of the Change

Some clients have reached out indicating that they are unable to get their IDXB pages to appear within the IDX Pages section of IMPress. Sometimes the pages disappear and sometimes they are never there at all. Even when trying to rerun the idx_create_idx_pages WP cron manually with a tool like WP Crontrol the pages fail to be created or recreated every time. 

The exact circumstances that cause this behavior are still unclear but after thoroughly investigating what happens on an affected developer partner client’s site I’ve determined some details and a possible fix. 

On the affected site when adding debug statements to the plugin’s code I found that when create_idx_pages() was being executed, it was always being directed into this if block:

```
        if ( empty( $uid_added ) ) {
            return wp_schedule_single_event( time(), 'idx_add_uid_to_idx_pages' );
        }
```

From reviewing the rest of the plugin’s code relating to this idx_add_uid_to_idx_pages event, it appears to be related to migrating data from a very old version of the plugin (<v1.3), see files add-uid-to-idx-pages.php and migrate-old-table.php within the backward-compatibility folder.

And even though the idx_add_uid_to_idx_pages event was scheduled, it never executed any action when run. I suspect the legacy code related to this <v1.3 migration procedure is no longer working as expected, but I cannot be sure as I cannot determine what it is supposed to do beyond converting what appears to be old, generic posts that used to be used for adding IDXB pages to a site into the custom post type that is used by our plugin. I suspect this may be related to how the older posts are attempted to be detected through the check in schedule_migrate_old_table in initiate-plugin.php since I believe _links_to is a meta_key used by several 3rd party plugins, but I cannot say for certain:


```
    /**
     * Schedule_migrate_old_table function.
     *
     * @access public
     * @return void
     */
    public function schedule_migrate_old_table() {
        global $wpdb;
        if ( $wpdb->get_var( 'SELECT post_id FROM ' . $wpdb->prefix . "postmeta WHERE meta_key = '_links_to'" ) !== null ) {
            if ( ! wp_get_schedule( 'idx_migrate_old_table' ) ) {
                wp_schedule_single_event( time(), 'idx_migrate_old_table' );
            }
        } else {
            // Make sure IDX pages update if migration is not necessary.
            update_option( 'idx_migrated_old_table', true, false );
        }
    }
 

```

Given that v1.3 is quite old now, I’m not sure if it’s necessary to keep a reference to this migration procedure especially as it is causing unexpected behavior in some circumstances like for some clients that are unable to pull in their IDXB pages. 


Skipping the check that schedules the idx_add_uid_to_idx_pages event allows for the pages to be generated as normal. This PR also sets idx_migrated_old_table and idx_add_uid_to_idx_pages to be true if the legacy posts_idx table is not detected.

### Verification Process

Developed fix while troubleshooting a client site. The exact circumstances that leads to the environment that causes this behavior is still unknown, so I cannot provide steps to reproduce this bug at this time. 

Attached is a zip file of the fix applied to 3.0.10 that can be used to see if it resolves the issue on an affected client's site. 

### Release Notes

Fix: More consistently generate IDX pages when the plugin is installed or reinstalled.

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.