### PR TITLE
IMPB-1498  Omnibar only searching for sold listings with IMPB-1465

### DIFF
--- a/src/js/idx-omnibar.js
+++ b/src/js/idx-omnibar.js
@@ -561,7 +561,7 @@ var idxOmnibar = function(jsonData){
 
 		// Quick fix for if using the address autocomplete
 		if(AddressFieldType === 'address') {
-			goToResultsPage(input, idxUrl, '?idxID=' + AddressMLS + '&pt=' + mlsPtId + '&aw_address=' + input.value  + '&idxStatus=active&idxStatus=sold');
+			goToResultsPage(input, idxUrl, '?idxID=' + AddressMLS + '&pt=' + mlsPtId + '&aw_address=' + input.value  + '&idxStatus[]=active&idxStatus[]=sold');
 			return;
 		}
 		
@@ -573,7 +573,7 @@ var idxOmnibar = function(jsonData){
 			//MLS Number/ListingID
 			var listingID = true;
 			var agentHeaderID = false;
-			goToResultsPage(input, idxUrl, '?csv_listingID=' + input.value + '&idxStatus=active&idxStatus=sold', listingID);
+			goToResultsPage(input, idxUrl, '?csv_listingID=' + input.value + '&idxStatus[]=active&idxStatus[]=sold', listingID);
 		} else {
 			//address (split into number and street)
 			var addressSplit = input.value.split(' ');
@@ -586,13 +586,13 @@ var idxOmnibar = function(jsonData){
 						addressName += '+' + addressSplit[i];
 					}
 				}
-				goToResultsPage(input, idxUrl, '?pt=' + mlsPtId + '&a_streetNumber=' + addressSplit[0] + '&aw_address=' + addressName + '&srt=' + sortOrder  + '&idxStatus=active&idxStatus=sold');
+				goToResultsPage(input, idxUrl, '?pt=' + mlsPtId + '&a_streetNumber=' + addressSplit[0] + '&aw_address=' + addressName + '&srt=' + sortOrder  + '&idxStatus[]=active&idxStatus[]=sold');
 			} else if(input.value === idxOmnibarPlaceholder){
 				//prevent placeholder from interfering with results URL
-				goToResultsPage(input, idxUrl, '?pt=' + mlsPtId + '&srt=' + sortOrder + '&idxStatus=active&idxStatus=sold');
+				goToResultsPage(input, idxUrl, '?pt=' + mlsPtId + '&srt=' + sortOrder + '&idxStatus[]=active&idxStatus[]=sold');
 			} else {
 				//search by just street name (without state or city if comma is used)
-				goToResultsPage(input, idxUrl, '?pt=' + mlsPtId + '&aw_address=' + input.value.split(', ')[0] + '&srt=' + sortOrder + '&idxStatus=active&idxStatus=sold');
+				goToResultsPage(input, idxUrl, '?pt=' + mlsPtId + '&aw_address=' + input.value.split(', ')[0] + '&srt=' + sortOrder + '&idxStatus[]=active&idxStatus[]=sold');
 			}
 		}
 	};


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Yes

## Template

### Description of the Change

Square brackets (like `[]`) are added to the idxStatus fields in the search page URLs used by the Omnibar to show Address and Listing ID searches to the user. This ensures that both sold and active listings can be shown in the search.

### Verification Process

1. Apply fix and rebuild plugin.
2. With rebuilt plugin active on a site, perform an Omnibar search for both a sold and active listing for both the listing ID search and the address search on a connected MLS.
3. Note that both sold and active listings are included in the search results.


### Release Notes

Fix: Omnibar address and listing ID search more consistently shows both sold and active listings in the results.


## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
