### PR TITLE
IMPB-1497-2 idx pages sometimes never populate through create idx pages

### DIFF
--- a/idx/idx-pages.php
+++ b/idx/idx-pages.php
@@ -204,6 +204,8 @@ class Idx_Pages {
 	 * @return mixed
 	 */
 	public function create_idx_pages() {
+		global $wpdb;
+		
 		// Only schedule update once IDX pages have UID.
 		$uid_added = get_option( 'idx_added_uid_to_idx_pages' );
 		


### PR DESCRIPTION
# Pull Requests

Additional commit for PR https://github.com/idxbroker/wordpress-plugin/pull/466

🐛 Are you fixing a bug? Yes

Remember to state clearly and in detail, leaving no room for confusion about the intent of your Pull Request

## Template

### Description of the Change

$wpdb needs to be declared as global to be used properly.

### Verification Process

With fix in place, confirmed that IDX Pages are pulled in on a new install, and new saved links that are created are pulled in on refresh.

### Release Notes

n/a


## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
