### PR TITLE
Impb 1247 fix rows

### DIFF
--- a/idx/widgets/create-impress-widgets.php
+++ b/idx/widgets/create-impress-widgets.php
@@ -292,7 +292,7 @@ class Create_Impress_Widgets {
 				// count is not equal to max AND
 				// count is not equal to total
 				if ( $count % $num_per_row == 0 && $count != $max && $count != $total ) {
-					$output .= '<div class="impress-row shortcode property-showcase">';
+					$output .= '<div class="row impress-row shortcode property-showcase">';
 				}
 			}
 		}

--- a/idx/widgets/create-impress-widgets.php
+++ b/idx/widgets/create-impress-widgets.php
@@ -292,7 +292,7 @@ class Create_Impress_Widgets {
 				// count is not equal to max AND
 				// count is not equal to total
 				if ( $count % $num_per_row == 0 && $count != $max && $count != $total ) {
-					$output .= '<div class="row shortcode property-showcase">';
+					$output .= '<div class="impress-row shortcode property-showcase">';
 				}
 			}
 		}

--- a/idx/widgets/impress-showcase-widget.php
+++ b/idx/widgets/impress-showcase-widget.php
@@ -305,7 +305,7 @@ class Impress_Showcase_Widget extends \WP_Widget {
 				// count is not equal to max AND
 				// count is not equal to total.
 				if ( $count % $num_per_row == 0 && $count != $max && $count != $total ) {
-					$output .= '<div class="row">';
+					$output .= '<div class="impress-row">';
 				}
 			}
 		}

--- a/idx/widgets/impress-showcase-widget.php
+++ b/idx/widgets/impress-showcase-widget.php
@@ -305,7 +305,7 @@ class Impress_Showcase_Widget extends \WP_Widget {
 				// count is not equal to max AND
 				// count is not equal to total.
 				if ( $count % $num_per_row == 0 && $count != $max && $count != $total ) {
-					$output .= '<div class="impress-row">';
+					$output .= '<div class="row impress-row">';
 				}
 			}
 		}

--- a/src/css/widgets/impress-showcase.css
+++ b/src/css/widgets/impress-showcase.css
@@ -40,6 +40,7 @@
     padding-left: 0.8333333333rem;
     padding-right: 0.8333333333rem;
     float: left;
+    box-sizing: border-box;
 }
 .impress-property-showcase .small-1 {
     width: 8.3333333333%;


### PR DESCRIPTION


### Description of the Change

Fixups for showcase widgets

Shortcode: add css styling so the rows don't end early

Page Builder plugins: add class so the rows don't end early

### Verification Process


What process did you follow to verify that your change has the desired effects?

Tested in local build on 3.1.0
Compared Shortcode, Builder Plugin, and WP gutenburg editor designs before and after each changed line of code

All designs match much better than before


### Release Notes

Fixed inconsistencies in IMPress showcase across different implementations


## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
