### PR TITLE
IMPB-1500  Changing the Update Frequency of IMPress removes Cron events 'create_idx_pages' and 'delete_idx_pages'

### DIFF
--- a/idx/initiate-plugin.php
+++ b/idx/initiate-plugin.php
@@ -88,6 +88,9 @@ class Initiate_Plugin {
 	 * @return void
 	 */
 	public function instantiate_classes() {
+		// Custom cron schedules need to be registered before classses are instantiated, otherwise some cron tasks won't be scheduled if a custom cron schedule is selected.
+		$this->register_cron_schedules();
+		
 		new Wrappers();
 		new Idx_Pages();
 		new Shortcodes\Register_Idx_Shortcodes();
@@ -108,8 +111,6 @@ class Initiate_Plugin {
 		}
 		// Check if reCAPTCHA option has been set. If it does not exist, a default of 1 will be set.
 		get_option( 'idx_recaptcha_enabled', 1 );
-
-		$this->register_cron_schedules();
 	}
 
 	/**


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Y

## Template

### Description of the Change

Custom cron schedules are registered in initiate-plugin.php, but prior to this PR were registered after all other classes were instantiated. This meant that if a class tried to schedule a WP cron event with a custom schedule, it would actually not be successfully scheduled.

Moving $this->register_cron_schedules(); to the top of instantiate_classes() resolves this issue.

### Verification Process

Attempt to change the update frequency of the plugin to a custom schedule like "twice a week" with and without the fix in place. You can use WP Crontrol to determine what events have been successfully scheduled.

### Release Notes

Fix: IMPress Cron events are scheduled more reliably 

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
