### PR TITLE
IMPB-1502 - Fix for wrong bathroom term in saved links

### DIFF
--- a/idx/views/search-management.php
+++ b/idx/views/search-management.php
@@ -130,7 +130,7 @@ class Search_Management {
 				'lp'    => sanitize_text_field( wp_unslash( $_POST['lp'] ) ),
 				'hp'    => sanitize_text_field( wp_unslash( $_POST['hp'] ) ),
 				'bd'    => sanitize_text_field( wp_unslash( $_POST['bd'] ) ),
-				'ba'    => sanitize_text_field( wp_unslash( $_POST['ba'] ) ),
+				'tb'    => sanitize_text_field( wp_unslash( $_POST['tb'] ) ),
 				'sqft'  => sanitize_text_field( wp_unslash( $_POST['sqft'] ) ),
 				'acres' => sanitize_text_field( wp_unslash( $_POST['acres'] ) ),
 				'add'   => sanitize_text_field( wp_unslash( $_POST['add'] ) ),
@@ -211,7 +211,7 @@ class Search_Management {
 				'lp'    => sanitize_text_field( wp_unslash( $_POST['lp'] ) ),
 				'hp'    => sanitize_text_field( wp_unslash( $_POST['hp'] ) ),
 				'bd'    => sanitize_text_field( wp_unslash( $_POST['bd'] ) ),
-				'ba'    => sanitize_text_field( wp_unslash( $_POST['ba'] ) ),
+				'tb'    => sanitize_text_field( wp_unslash( $_POST['tb'] ) ),
 				'sqft'  => sanitize_text_field( wp_unslash( $_POST['sqft'] ) ),
 				'acres' => sanitize_text_field( wp_unslash( $_POST['acres'] ) ),
 				'add'   => sanitize_text_field( wp_unslash( $_POST['add'] ) ),
@@ -432,8 +432,8 @@ class Search_Management {
 					<label class="mdl-textfield__label" for="bd">Beds</label>
 				</div>
 				<div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label one-third">
-					<input class="mdl-textfield__input" type="text" id="ba" name="ba">
-					<label class="mdl-textfield__label" for="ba">Baths</label>
+					<input class="mdl-textfield__input" type="text" id="tb" name="tb">
+					<label class="mdl-textfield__label" for="tb">Baths</label>
 				</div><br />
 				<div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label one-third">
 					<input class="mdl-textfield__input" type="text" id="sqft" name="sqft">
@@ -563,8 +563,8 @@ class Search_Management {
 					<label class="mdl-textfield__label" for="bd">Beds</label>
 				</div>
 				<div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-					<input class="mdl-textfield__input" type="text" id="ba" name="ba">
-					<label class="mdl-textfield__label" for="ba">Baths</label>
+					<input class="mdl-textfield__input" type="text" id="tb" name="tb">
+					<label class="mdl-textfield__label" for="tb">Baths</label>
 				</div><br />
 				<div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
 					<input class="mdl-textfield__input" type="text" id="sqft" name="sqft">

--- a/src/js/idx-searches.js
+++ b/src/js/idx-searches.js
@@ -45,7 +45,7 @@ jQuery(document).ready(function($) {
 		var lp = $('#lp').val();
 		var hp = $('#hp').val();
 		var bd = $('#bd').val();
-		var ba = $('#ba').val();
+		var tb = $('#tb').val();
 		var sqft = $('#sqft').val();
 		var acres = $('#acres').val();
 		var add = $('#add').val();
@@ -107,7 +107,7 @@ jQuery(document).ready(function($) {
 				lp: lp,
 				hp: hp,
 				bd: bd,
-				ba: ba,
+				tb: tb,
 				sqft: sqft,
 				acres: acres,
 				add: add,
@@ -145,7 +145,7 @@ jQuery(document).ready(function($) {
 		var lp = $('#lp').val();
 		var hp = $('#hp').val();
 		var bd = $('#bd').val();
-		var ba = $('#ba').val();
+		var tb = $('#tb').val();
 		var sqft = $('#sqft').val();
 		var acres = $('#acres').val();
 		var add = $('#add').val();
@@ -179,7 +179,7 @@ jQuery(document).ready(function($) {
 				lp: lp,
 				hp: hp,
 				bd: bd,
-				ba: ba,
+				tb: tb,
 				sqft: sqft,
 				acres: acres,
 				add: add,


### PR DESCRIPTION
We don't use `ba` in search, we use `tb`

updating saved link creation, and the forms that create them to use `tb`