### PR TITLE
IMPB-1508 "Feeds for YouTube Pro Personal" Smash Balloon plugin causes a vue conflict when enabled alongside IMPress resulting in the General Settings page to be non-functional

### DIFF
--- a/idx/initiate-plugin.php
+++ b/idx/initiate-plugin.php
@@ -77,6 +77,8 @@ class Initiate_Plugin {
 				// Graphs & Charts plugin.
 				wp_dequeue_script( 'Graphs & Charts' );
 				wp_deregister_script( 'Graphs & Charts' );
+				// Feeds for YouTube Pro Personal
+				wp_dequeue_script('feed-builder-vue');
 			}
 		}
 	}


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Y

## Template

### Description of the Change

If IMPress and  "Feeds for YouTube Pro Personal" Smash Balloon are simultaneously enabled on a WordPress site, the General Settings page for IMPress will be blank due to a vue conflict.


This PR dequeues the vue script that the Smash Balloon plugin tries to load when using the admin area for IMPress.


### Verification Process

Try using the General Settings page with both plugins enabled with and without the fix in place.

### Release Notes

Fix: resolve conflict between IMPress and "Feeds for YouTube Pro Personal" by Smash Balloon 

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
