### PR TITLE
IMPB-1509 correct typo in find_and_update_post() to properly compare post slug and link url when updating IDX pages

### DIFF
--- a/idx/idx-pages.php
+++ b/idx/idx-pages.php
@@ -325,9 +325,9 @@ class Idx_Pages {
 			$matchingPostWithName = null;
 			foreach ( $matchingPosts as $matchingPost ) {
 				// It's possible for a post to already have the expected post name (slug), if we find one with this characteristic it should be kept over others
-				$nameMatches = $matchingPost->name == $link->url;
+				$nameMatches = $matchingPost->post_name == $link->url;
 				if ($nameMatches) {
-					error_log("impress find_and_update_post found a matching post for $link, $name: " . $matchingPost->ID);
+					error_log("impress find_and_update_post found a matching post for $link->url, $name: " . $matchingPost->ID);
 					$matchingPostWithName = $matchingPost;
 				}
 			}


### PR DESCRIPTION

# Pull Requests

🐛 Are you fixing a bug? Y

## Template

### Description of the Change

Fix typo in find_and_update_post() to properly compare the page slug with the url of an IDX page when IDX pages are updated by IMPress

### Verification Process

Run the 3.1.0 version plugin with and without the fix with an instance of a WordPress site that has duplicate posts for an IDX page and observe that with the fix in place the IDX page with a page slug that matches the url of the IDX page is retained, while without the fix in place the oldest IDX page is retained instead.

### Release Notes

N/A

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
