### PR TITLE
IMPB-1510 Listings imported with IMPress Listings do not include the MLS disclaimer

### DIFF
--- a/add-ons/listings/includes/class-listing-import.php
+++ b/add-ons/listings/includes/class-listing-import.php
@@ -68,7 +68,7 @@ class WPL_Idx_Listing {
 
 		// Load IDX Broker API Class and retrieve featured properties.
 		$_idx_api   = new \IDX\Idx_Api();
-		$properties = $_idx_api->client_properties( 'featured?disclaimers=true' );
+		$properties = $_idx_api->client_properties( 'featured' );
 
 		// Load WP options.
 		$wpl_import_options = get_option( 'wp_listings_idx_featured_listing_wp_options' );
@@ -179,7 +179,7 @@ class WPL_Idx_Listing {
 
 		// Load IDX Broker API Class and retrieve featured properties.
 		$_idx_api = new \IDX\Idx_Api();
-		$properties = $_idx_api->client_properties( 'featured?disclaimers=true' );
+		$properties = $_idx_api->client_properties( 'featured' );
 
 		// Load WP options
 		$idx_featured_listing_wp_options = get_option( 'wp_listings_idx_featured_listing_wp_options' );

--- a/add-ons/listings/includes/views/single-listing.php
+++ b/add-ons/listings/includes/views/single-listing.php
@@ -123,9 +123,9 @@ function single_listing_post_content() {
 				echo ( get_post_meta( $post->ID, '_listing_featured_on', true ) ) ? '<p class="wp_listings_featured_on">' . esc_html( get_post_meta( $post->ID, '_listing_featured_on', true ) ) . '</p>' : '';
 
 				if ( get_post_meta( $post->ID, '_listing_disclaimer', true ) ) {
-					echo '<p class="wp-listings-disclaimer">' . esc_html( get_post_meta( $post->ID, '_listing_disclaimer', true ) ) . '</p>';
+					echo '<p class="wp-listings-disclaimer">' . get_post_meta( $post->ID, '_listing_disclaimer', true ) . '</p>';
 				} elseif ( ! empty( $options['wp_listings_global_disclaimer'] ) ) {
-					echo '<p class="wp-listings-disclaimer">' . esc_html( $options['wp_listings_global_disclaimer'] ) . '</p>';
+					echo '<p class="wp-listings-disclaimer">' . $options['wp_listings_global_disclaimer'] . '</p>';
 				}
 
 				if ( class_exists( 'Idx_Broker_Plugin' ) && ! empty( $options['wp_listings_display_idx_link'] ) && get_post_meta( $post->ID, '_listing_details_url', true ) ) {

--- a/idx/idx-api.php
+++ b/idx/idx-api.php
@@ -608,7 +608,7 @@ class Idx_Api {
 	/**
 	 * Client_properties function.
 	 * Expected $type posibilities: featured, soldpending, supplemental.
-	 * 
+	 * Note that ?disclaimers=true will be added to the end of the request, so there's no need to include it in $type
 	 * @access public
 	 * @param string $type
 	 * @return array


### PR DESCRIPTION
# Pull Requests

Please explain the intent of your Pull Request.

🐛 Are you fixing a bug? Y

## Template

### Description of the Change

wp_listings_idx_create_post() erroneously includes ?disclaimers=true when requesting listing information from the API to import listings into a site. Since the client_properties() function in idx-api.php appends ?disclaimers=true to requests made through it, this results in an API call like /clients/featured?disclaimers=true?disclaimers=true being sent which will not return listing information with a disclaimer.

### Verification Process

Import a listing through IMPress listings with and without the fix in place.

### Release Notes

Fix: Better include MLS disclaimer when importing listings with IMPress listings

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
