### PR TITLE
IMPB-1513  non-US state abbreviations like those from a650 VNMLS are not detected by the Omnibar search JS, causing incorrect search results

### DIFF
--- a/src/js/idx-omnibar.js
+++ b/src/js/idx-omnibar.js
@@ -45,8 +45,20 @@ var idxOmnibar = function(jsonData){
 		}
 		return displayName;
 	};
+
+	let includedStateAbreviations = new Set();
+
 	//helper function for grabbing the name of each item in JSON creating new array
 	var createArrays = function(array, newArray, type, fieldName){
+		
+		// Add state abbreviations to the set for later reference
+		array.forEach((item) => {
+			if (item.stateAbrv) {
+				console.log(item.stateAbrv);
+				includedStateAbreviations.add(item.stateAbrv);
+			}
+		});
+
 		//if zip, do not append state abbreviations
 		if(type === 'zip'){
 			array.forEach(function(item){
@@ -54,6 +66,8 @@ var idxOmnibar = function(jsonData){
 				if(item.name !== '' && item.name !== 'Other' && item.name !== 'Other State'){
 					newArray.push(item.name);
 				}
+
+
 			});
 			//if county, append County and State
 		} else if(type ==='county') {
@@ -479,7 +493,11 @@ var idxOmnibar = function(jsonData){
 		}
 		for(var i=0; i < list.length; i++){
 			//filter out blank and county from input and check for appended state
-			if (inputFiltered.split(' county')[0] === list[i].name.toLowerCase() && whatState(input.value.split(', ')[1], list[i].stateAbrv, stateException) && isCounty(inputFiltered.split(' county')[1], listType) && input.value) {
+			if (inputFiltered.split(' county')[0] === list[i].name.toLowerCase() 
+			&& (
+				whatState(input.value.split(', ')[1], list[i].stateAbrv, stateException)
+				|| includedStateAbreviations.has(input.value.split(', ')[1].toUpperCase())) 
+			&& isCounty(inputFiltered.split(' county')[1], listType) && input.value) {
 				switch(listType){
 					case 'cities':
 						foundResult = true;


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Y

The plugin uses a hardcoded list of states to detect when parsing the Omnibar input and trying to determine what CCZ id should be used when handling an input like “City, StateAbreviation”. 

Some example state abbreviations from VNMLS include JAL and NAY. These are not included in the current hardcoded list, so they are not detected by the whatState function. This results in an address search being performed even if a valid state abbreviation is entered, which usually results in 0 results.

## Template

### Description of the Change

A set is used to keep track of all state abbreviations found in the locationlist.js file for later reference when the user input is parsed to determine what type of search to make. 

### Verification Process

1. Add the API key of an account using a650 VNMLS to a test WordPress site.
2. Add the Omnibar to a test page on the site and publish the page.
3. Type in "Airport" and press enter. It should autocomplete to "Airport, JAL".
4. Submit the search through the Omnibar. 
5. Note that the search results you are directed to are for an address search for Airport, like "idx/results/listings?pt=&aw_address=Airport&srt=&idxStatus[]=active&idxStatus[]=sold"
6. Apply the fix in the PR to the plugin.
7. Re-gulp the JS and apply the changes to the test site.
8. Refresh the Omnibar page and perform the same search starting with typing in "Airport"
9. Note that you are now correctly directed to a search using the CCZ ID for Airport, JAL, like "idx/results/listings?pt=&ccz=city&city[]=20&srt="

### Release Notes

Fix: Handle more non-US state abbreviations when performing an Omnibar search.

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
