### PR TITLE
IMPB-1518  IMPress plugin ignoring update-excluding-images setting

### DIFF
--- a/add-ons/listings/includes/class-listing-import.php
+++ b/add-ons/listings/includes/class-listing-import.php
@@ -193,7 +193,7 @@ class WPL_Idx_Listing {
 				if ( ! isset( $wpl_options['wp_listings_idx_update'] )
 						|| isset( $wpl_options['wp_listings_idx_update'] )
 						&& 'update-none' !== $wpl_options['wp_listings_idx_update'] ) {
-						self::wp_listings_idx_insert_post_meta( $idx_featured_listing_wp_options[ $prop['listingID'] ]['post_id'], $properties[ $key ], true, ( ! empty( $wpl_options['wp_listings_idx_update'] ) && 'update-noimage' === $wpl_options['wp_listings_idx_update'] ) ? false : true, false );
+						self::wp_listings_idx_insert_post_meta( $idx_featured_listing_wp_options[ $prop['listingID'] ]['post_id'], $properties[ $key ], true, ( ! empty( $wpl_options['wp_listings_idx_update'] ) && 'update-excluding-images' === $wpl_options['wp_listings_idx_update'] ) ? false : true, false );
 				}
 
 				$idx_featured_listing_wp_options[ $prop['listingID'] ]['updated'] = date( 'm/d/Y h:i:sa' );
@@ -209,7 +209,7 @@ class WPL_Idx_Listing {
 			if ( isset( $idx_featured_listing_wp_options[ $sold_prop['listingID'] ]['post_id'] ) ) {
 
 				// Update property data.
-				self::wp_listings_idx_insert_post_meta( $idx_featured_listing_wp_options[ $sold_prop['listingID'] ]['post_id'], $sold_properties[ $key ], true, ( ! empty( $wpl_options['wp_listings_idx_update'] ) && 'update-noimage' === $wpl_options['wp_listings_idx_update'] ) ? false : true, true );
+				self::wp_listings_idx_insert_post_meta( $idx_featured_listing_wp_options[ $sold_prop['listingID'] ]['post_id'], $sold_properties[ $key ], true, ( ! empty( $wpl_options['wp_listings_idx_update'] ) && 'update-excluding-images' === $wpl_options['wp_listings_idx_update'] ) ? false : true, true );
 
 				if ( isset( $wpl_options['wp_listings_idx_sold'] ) && 'sold-draft' === $wpl_options['wp_listings_idx_sold'] ) {
 


### PR DESCRIPTION
# Pull Requests

🐛 Are you fixing a bug? Yes

## Template

### Description of the Change

'update-excluding-images' is the string that the wp_listings_idx_update option is set to when the user chooses the 'Update Excluding Images' setting when configuring their options for IMPress Listings and how listings are imported and updated. 

Prior to this PR, the 'update-noimage' is the string used by the plugin to verify whether 'Update Excluding Images' has been set. This results in the setting being effectively ignored with images continuing to be updated even when it is set by the user.

### Verification Process

Import a supplemental listing with an image into IMPress, update its image within the test IDX Broker account, and then update listings within IMPress again and note that the image will always update even if 'Update Excluding Images' is set.

Then apply the fix and perform the same tests to see that the image will now not be update if 'Update Excluding Images' is set.

### Release Notes

Fix: 'Update Excluding Images' setting for IMPress Listings will correctly prevent images from being updated for already imported listings.

## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
