### PR TITLE
IMPB-1499: Fixed error for string expectation

### DIFF
--- a/idx/views/lead-management.php
+++ b/idx/views/lead-management.php
@@ -168,7 +168,7 @@ class Lead_Management {
 
 			$decoded_response = json_decode( $response['body'], 1 );
 
-			if ( str_contains($decoded_response, 'Lead already exists') ) {
+			if ( str_contains("$decoded_response", 'Lead already exists') ) {
 				echo 'Lead already exists.';
 			} elseif ( wp_remote_retrieve_response_code( $response ) == '200' ) {
 				// Delete lead cache so new lead will show in list views immediately.


### PR DESCRIPTION
Fixed an error with str_contains($string, $string). If we were able to successfully add the lead then the $decoded_response would be an array.