### PR TITLE
Fix incorrect use of esc_html_e() in wp_die() calls

### DIFF
--- a/add-ons/agents/includes/class-taxonomies.php
+++ b/add-ons/agents/includes/class-taxonomies.php
@@ -111,17 +111,17 @@ class IMPress_Agents_Taxonomies {
 
 		// Check permissions.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html_e( 'Manage options capabilities required to create a taxonomy.', 'impress_agents' ) );
+			wp_die( esc_html__( 'Manage options capabilities required to create a taxonomy.', 'impress_agents' ) );
 		}
 		/** No empty fields */
 		if ( ! isset( $args['id'] ) || empty( $args['id'] ) ) {
-			wp_die( esc_html_e( 'Please complete all required fields.', 'impress_agents' ) );
+			wp_die( esc_html__( 'Please complete all required fields.', 'impress_agents' ) );
 		}
 		if ( ! isset( $args['name'] ) || empty( $args['name'] ) ) {
-			wp_die( esc_html_e( 'Please complete all required fields.', 'impress_agents' ) );
+			wp_die( esc_html__( 'Please complete all required fields.', 'impress_agents' ) );
 		}
 		if ( ! isset( $args['singular_name'] ) || empty( $args['singular_name'] ) ) {
-			wp_die( esc_html_e( 'Please complete all required fields.', 'impress_agents' ) );
+			wp_die( esc_html__( 'Please complete all required fields.', 'impress_agents' ) );
 		}
 
 		extract( $args );
@@ -168,11 +168,11 @@ class IMPress_Agents_Taxonomies {
 
 		// Check permissions.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html_e( 'Manage options capabilities required to delete a taxonomy.', 'impress_agents' ) );
+			wp_die( esc_html__( 'Manage options capabilities required to delete a taxonomy.', 'impress_agents' ) );
 		}
 		/** No empty ID */
 		if ( ! isset( $id ) || empty( $id ) ) {
-			wp_die( esc_html_e( "Nice try, partner. But that taxonomy doesn't exist. Click back and try again.", 'impress_agents' ) );
+			wp_die( esc_html__( "Nice try, partner. But that taxonomy doesn't exist. Click back and try again.", 'impress_agents' ) );
 		}
 
 		$options = get_option( $this->settings_field );
@@ -181,7 +181,7 @@ class IMPress_Agents_Taxonomies {
 		if ( array_key_exists( $id, (array) $options ) ) {
 			unset( $options[$id] );
 		} else {
-			wp_die( esc_html_e( "Nice try, partner. But that taxonomy doesn't exist. Click back and try again.", 'impress_agents' ) );
+			wp_die( esc_html__( "Nice try, partner. But that taxonomy doesn't exist. Click back and try again.", 'impress_agents' ) );
 		}
 
 		/** Update the DB */
@@ -193,17 +193,17 @@ class IMPress_Agents_Taxonomies {
 
 		// Check permissions.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html_e( 'Manage options capabilities required to edit a taxonomy.', 'impress_agents' ) );
+			wp_die( esc_html__( 'Manage options capabilities required to edit a taxonomy.', 'impress_agents' ) );
 		}
 		/** No empty fields */
 		if ( ! isset( $args['id'] ) || empty( $args['id'] ) ) {
-			wp_die( esc_html_e( 'Please complete all required fields.', 'impress_agents' ) );
+			wp_die( esc_html__( 'Please complete all required fields.', 'impress_agents' ) );
 		}
 		if ( ! isset( $args['name'] ) || empty( $args['name'] ) ) {
-			wp_die( esc_html_e( 'Please complete all required fields.', 'impress_agents' ) );
+			wp_die( esc_html__( 'Please complete all required fields.', 'impress_agents' ) );
 		}
 		if ( ! isset( $args['singular_name'] ) || empty( $args['singular_name'] ) ) {
-			wp_die( esc_html_e( 'Please complete all required fields.', 'impress_agents' ) );
+			wp_die( esc_html__( 'Please complete all required fields.', 'impress_agents' ) );
 		}
 
 		extract( $args );

--- a/add-ons/listings/includes/class-taxonomies.php
+++ b/add-ons/listings/includes/class-taxonomies.php
@@ -104,7 +104,7 @@ class WP_Listings_Taxonomies {
 
 		// Check permissions.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html_e( 'Manage options capabilities required to create a taxonomy.', 'wp_listings' ) );
+			wp_die( esc_html__( 'Manage options capabilities required to create a taxonomy.', 'wp_listings' ) );
 		}
 		/** No empty fields */
 		if ( ! isset( $args['id'] ) || empty( $args['id'] ) ) {
@@ -161,7 +161,7 @@ class WP_Listings_Taxonomies {
 
 		// Check permissions.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html_e( 'Manage options capabilities required to delete a taxonomy.', 'wp_listings' ) );
+			wp_die( esc_html__( 'Manage options capabilities required to delete a taxonomy.', 'wp_listings' ) );
 		}
 		/** No empty ID */
 		if ( ! isset( $id ) || empty( $id ) ) {
@@ -186,7 +186,7 @@ class WP_Listings_Taxonomies {
 
 		// Check permissions.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html_e( 'Manage options capabilities required to edit a taxonomy.', 'wp_listings' ) );
+			wp_die( esc_html__( 'Manage options capabilities required to edit a taxonomy.', 'wp_listings' ) );
 		}
 		/** No empty fields */
 		if ( ! isset( $args['id'] ) || empty( $args['id'] ) ) {


### PR DESCRIPTION
# Pull Requests

Fixed Function in two files

🐛 Are you fixing a bug?

Yes

📝 Are you updating documentation?

💻 Are you changing functionality?

No

## Template

### Description of the Change

This pull request fixes incorrect usage of translation functions in two files. Specifically, several lines of code were using `esc_html_e()` inside `wp_die()`, which is not appropriate since `esc_html_e()` echoes the translated string instead of returning it.
The calls have been updated to use `esc_html__()`, which correctly returns the translated string for use within `wp_die()`.

### Why This Change

- Prevents unintended output when calling `wp_die()`.
- Ensures proper handling of translated strings.
- Aligns with WordPress best practices for internationalization.

### Verification Process


What process did you follow to verify that your change has the desired effects? Yes

- How did you verify that all new functionality works as expected? Yes
- How did you verify that all changed functionality works as expected? Yes
- How did you verify that the change has not introduced any regressions? Yes

### Release Notes

Not applicable


## Review

Pull Requests must have the sign-off of two other developers and at least one of these must be an IDX Broker team member.
